### PR TITLE
Fix experimental flag usage

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,9 +23,10 @@ dependencies {
     implementation(libs.guava)
     implementation(libs.jgit)
 
-    testImplementation(platform(libs.microtus.bom))
     testImplementation(libs.junit.jupiter)
+    testImplementation(libs.junit.jupiter.params)
     testRuntimeOnly(libs.junit.jupiter.engine)
+    testRuntimeOnly(libs.junit.platform.launcher)
 }
 
 tasks {
@@ -35,7 +36,7 @@ tasks {
     }
 
     jacocoTestReport {
-        dependsOn(rootProject.tasks.test)
+        dependsOn(test)
         reports {
             xml.required.set(true)
             csv.required.set(true)
@@ -43,8 +44,8 @@ tasks {
     }
 
     test {
-        finalizedBy(rootProject.tasks.jacocoTestReport)
         useJUnitPlatform()
+        finalizedBy(jacocoTestReport)
         testLogging {
             events("passed", "skipped", "failed")
         }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -12,7 +12,7 @@ dependencyResolutionManagement {
             library("dartpoet", "dev.themeinerlp", "dartpoet").version("0.0.1-SNAPSHOT")
             library("guava", "com.google.guava", "guava").version("33.4.0-jre")
             library("jgit", "org.eclipse.jgit", "org.eclipse.jgit").version("7.1.0.202411261347-r")
-            library("junit.jupiter", "org.junit.jupiter", "junit-jupiter").versionRef("junit")
+            library("junit.jupiter", "org.junit.jupiter", "junit-jupiter-api").versionRef("junit")
             library("junit.jupiter.engine", "org.junit.jupiter", "junit-jupiter-engine").versionRef("junit")
             plugin("kotlin", "org.jetbrains.kotlin.jvm").versionRef("kotlin")
         }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -13,7 +13,9 @@ dependencyResolutionManagement {
             library("guava", "com.google.guava", "guava").version("33.4.0-jre")
             library("jgit", "org.eclipse.jgit", "org.eclipse.jgit").version("7.1.0.202411261347-r")
             library("junit.jupiter", "org.junit.jupiter", "junit-jupiter-api").versionRef("junit")
+            library("junit.jupiter.params", "org.junit.jupiter", "junit-jupiter-params").versionRef("junit")
             library("junit.jupiter.engine", "org.junit.jupiter", "junit-jupiter-engine").versionRef("junit")
+            library("junit.platform.launcher", "org.junit.platform", "junit-platform-launcher").version("1.10.2")
             plugin("kotlin", "org.jetbrains.kotlin.jvm").versionRef("kotlin")
         }
     }

--- a/src/main/kotlin/net/theevilreaper/stelaris/cli/StelarisCLI.kt
+++ b/src/main/kotlin/net/theevilreaper/stelaris/cli/StelarisCLI.kt
@@ -18,7 +18,7 @@ fun main(args: Array<String>) {
     val generatorRegistry = GeneratorRegistry()
     var showHelp = false
     var versionPart: VersionPart? = null
-    var generators: Set<Generator> = generatorRegistry.generators
+    var experimental: Boolean = false
 
     args.forEachIndexed { index, arg ->
         if (arg.startsWith(ARGUMENT_IDENTIFIER)) {
@@ -44,13 +44,18 @@ fun main(args: Array<String>) {
                     versionPart = VersionPart.parse(versionPartString)
                 }
 
-                CommandArgument.EXPERIMENTAL -> generators = generatorRegistry.generators
+                CommandArgument.EXPERIMENTAL -> experimental = true
             }
         }
     }
 
     if (showHelp) {
         println(HELP_MESSAGE)
+    }
+
+    val generators: Set<Generator> = when(experimental) {
+        true -> generatorRegistry.getGenerators { it.isExperimental() }
+        false -> generatorRegistry.getGenerators()
     }
 
     if (generators.isEmpty()) {

--- a/src/main/kotlin/net/theevilreaper/stelaris/cli/StelarisCLI.kt
+++ b/src/main/kotlin/net/theevilreaper/stelaris/cli/StelarisCLI.kt
@@ -54,8 +54,8 @@ fun main(args: Array<String>) {
     }
 
     val generators: Set<Generator> = when(experimental) {
-        true -> generatorRegistry.getGenerators { it.isExperimental() }
-        false -> generatorRegistry.getGenerators()
+        false -> generatorRegistry.getGenerators { !it.isExperimental() }
+        true -> generatorRegistry.getGenerators()
     }
 
     if (generators.isEmpty()) {
@@ -66,6 +66,8 @@ fun main(args: Array<String>) {
     val tempFile: Path = Files.createTempDirectory(TEMP_DIR_NAME)
 
     MinecraftServer.init();
+
+    generators.forEach { generator -> generator.generate(tempFile) }
 
     val gitRepo = cloneBaseRepo(
         System.getenv("stelaris.cli.username"),

--- a/src/main/kotlin/net/theevilreaper/stelaris/cli/generator/Generator.kt
+++ b/src/main/kotlin/net/theevilreaper/stelaris/cli/generator/Generator.kt
@@ -3,26 +3,37 @@ package net.theevilreaper.stelaris.cli.generator
 import java.nio.file.Path
 
 /**
- * The interface defines some basic structure for generators
+ * The interface defines the basic structure for code generators in the Stelaris CLI.
+ * All generator implementations must follow this contract.
  * @author Joltras
  * @version 1.0.0
- * @author 1.0.0
+ * @since 1.0.0
  */
 interface Generator {
 
     /**
-     * Each generator must implement his own logic for this method
+     * Executes the generation process with the implementation-specific logic.
+     * @param javaPath the output directory path where the generated files should be written
      */
     fun generate(javaPath: Path)
 
     /**
      * Returns the name from the generator.
-     * @return the given generator name
+     * This is used to identify the generator in logs and other output.
+     * @return the generator's identifying name
      */
     fun getName(): String
 
     /**
-     * Contains logic to clean up the generator data structure.
+     * Cleans up any resources or state data used by the generator.
+     * This should be called after generation is complete.
      */
     fun cleanUp()
+
+    /**
+     * Indicates if the generator is considered experimental.
+     * Experimental generators may have incomplete functionality or be subject to change.
+     * @return true if the generator is experimental, false otherwise
+     */
+    fun isExperimental(): Boolean
 }

--- a/src/main/kotlin/net/theevilreaper/stelaris/cli/generator/GeneratorRegistry.kt
+++ b/src/main/kotlin/net/theevilreaper/stelaris/cli/generator/GeneratorRegistry.kt
@@ -2,9 +2,16 @@ package net.theevilreaper.stelaris.cli.generator
 
 import net.theevilreaper.stelaris.cli.generator.dart.*
 
+/**
+ * The [GeneratorRegistry] holds all available generators which can be used to generate dart files.
+ * @version 1.0.0
+ * @since 1.0.0
+ * @property generators the set of all available generators
+ * @author theEvilReaper
+ */
 class GeneratorRegistry {
 
-     val generators: Set<Generator> = setOf(
+    private val generators: Set<Generator> = setOf(
         BossBarGenerator(),
         EffectGenerator(),
         EnchantmentGenerator(),
@@ -13,4 +20,19 @@ class GeneratorRegistry {
         MaterialGenerator(),
         SoundTypeGenerator(),
     )
+
+    /**
+     * Returns all available generators from the registry
+     * @return a set of all available generators
+     */
+    fun getGenerators(): Set<Generator> = generators
+
+    /**
+     * Returns all available generators which match the given predicate
+     * @param predicate the predicate to filter the generators
+     * @return a set of all available generators which match the predicate
+     */
+    fun getGenerators(predicate: (Generator) -> Boolean): Set<Generator> {
+        return generators.filter { predicate(it) }.toSet()
+    }
 }

--- a/src/main/kotlin/net/theevilreaper/stelaris/cli/generator/dart/BossBarGenerator.kt
+++ b/src/main/kotlin/net/theevilreaper/stelaris/cli/generator/dart/BossBarGenerator.kt
@@ -143,4 +143,6 @@ class BossBarGenerator : BaseGenerator(
      * @return the given name
      */
     override fun getName(): String = "BossBarGenerator"
+
+    override fun isExperimental() = false
 }

--- a/src/main/kotlin/net/theevilreaper/stelaris/cli/generator/dart/EffectGenerator.kt
+++ b/src/main/kotlin/net/theevilreaper/stelaris/cli/generator/dart/EffectGenerator.kt
@@ -46,4 +46,6 @@ class EffectGenerator : BaseGenerator(
     }
 
     override fun getName(): String = "EffectGenerator"
+
+    override fun isExperimental() = false
 }

--- a/src/main/kotlin/net/theevilreaper/stelaris/cli/generator/dart/EnchantmentGenerator.kt
+++ b/src/main/kotlin/net/theevilreaper/stelaris/cli/generator/dart/EnchantmentGenerator.kt
@@ -72,4 +72,6 @@ class EnchantmentGenerator : BaseGenerator(
      * @return the given name
      */
     override fun getName() = "EnchantmentGenerator"
+
+    override fun isExperimental() = false
 }

--- a/src/main/kotlin/net/theevilreaper/stelaris/cli/generator/dart/EntityTypeGenerator.kt
+++ b/src/main/kotlin/net/theevilreaper/stelaris/cli/generator/dart/EntityTypeGenerator.kt
@@ -50,4 +50,6 @@ class EntityTypeGenerator : BaseGenerator(
     }
 
     override fun getName() = "EntityTypeGenerator"
+
+    override fun isExperimental() = false
 }

--- a/src/main/kotlin/net/theevilreaper/stelaris/cli/generator/dart/FrameTypeGenerator.kt
+++ b/src/main/kotlin/net/theevilreaper/stelaris/cli/generator/dart/FrameTypeGenerator.kt
@@ -46,4 +46,6 @@ class FrameTypeGenerator : BaseGenerator(
     }
 
     override fun getName() = "FrameTypeGenerator"
+
+    override fun isExperimental() = false
 }

--- a/src/main/kotlin/net/theevilreaper/stelaris/cli/generator/dart/MaterialGenerator.kt
+++ b/src/main/kotlin/net/theevilreaper/stelaris/cli/generator/dart/MaterialGenerator.kt
@@ -82,4 +82,6 @@ class MaterialGenerator : BaseGenerator(
      * @return the given name
      */
     override fun getName() = "MaterialGenerator"
+
+    override fun isExperimental() = false
 }

--- a/src/main/kotlin/net/theevilreaper/stelaris/cli/generator/dart/SoundTypeGenerator.kt
+++ b/src/main/kotlin/net/theevilreaper/stelaris/cli/generator/dart/SoundTypeGenerator.kt
@@ -43,4 +43,6 @@ class SoundTypeGenerator : BaseGenerator(
     }
 
     override fun getName(): String = "SoundTypeGenerator"
+
+    override fun isExperimental() = true
 }

--- a/src/test/kotlin/net/theevilreaper/stelaris/cli/generator/GeneratorRegistryTest.kt
+++ b/src/test/kotlin/net/theevilreaper/stelaris/cli/generator/GeneratorRegistryTest.kt
@@ -1,0 +1,22 @@
+package net.theevilreaper.stelaris.cli.generator
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+
+class GeneratorRegistryTest {
+
+    @Test
+    fun testGetGenerators() {
+        val generatorRegistry = GeneratorRegistry()
+        val generators = generatorRegistry.getGenerators()
+        assertEquals(7, generators.size)
+    }
+
+    @Test
+    fun testGetGeneratorsWithPredicate() {
+        val generatorRegistry = GeneratorRegistry()
+        val generators = generatorRegistry.getGenerators { it.isExperimental() }
+        assertFalse(generators.isEmpty())
+        assertEquals(1, generators.size)
+    }
+}


### PR DESCRIPTION
## Description

The cli has an option to enable generators which flagged as experimental. The idea is quite good but the structure of the `Generator` doesn't provide such option. This pull request adds a flag to the structure to support that command flag

### Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] I read and followed the [contribution guidelines]
