### PR TITLE
chore: Improve enum constant generation

### DIFF
--- a/src/main/kotlin/net/theevilreaper/stelaris/cli/generator/dart/EntityTypeGenerator.kt
+++ b/src/main/kotlin/net/theevilreaper/stelaris/cli/generator/dart/EntityTypeGenerator.kt
@@ -23,11 +23,13 @@ class EntityTypeGenerator : BaseGenerator(
         val models = EntityType.values()
         val enumEntries = mutableListOf<EnumEntrySpec>()
         for (type in models) {
-            val name = type.name().replace("minecraft:", EMPTY_STRING)
+            val nameWithOutMinecraftPrefix = type.name().replace("minecraft:", EMPTY_STRING)
+            val variableName = StringHelper.toLowerCamelCase(nameWithOutMinecraftPrefix)
+            val name = StringHelper.mapDisplayName(nameWithOutMinecraftPrefix)
             enumEntries.add(
-                EnumEntrySpec.builder(name.lowercase())
-                    .parameter(EnumParameterSpec.positional("%C", StringHelper.mapDisplayName(name)))
+                EnumEntrySpec.builder(variableName)
                     .parameter(EnumParameterSpec.positional("%C", name))
+                    .parameter(EnumParameterSpec.positional("%C", type.name()))
                     .build()
             )
         }

--- a/src/main/kotlin/net/theevilreaper/stelaris/cli/generator/dart/enchantment/EnchantmentGenerator.kt
+++ b/src/main/kotlin/net/theevilreaper/stelaris/cli/generator/dart/enchantment/EnchantmentGenerator.kt
@@ -1,6 +1,5 @@
 package net.theevilreaper.stelaris.cli.generator.dart.enchantment
 
-import com.google.common.collect.ImmutableList
 import net.kyori.adventure.text.TranslatableComponent
 import net.minestom.server.MinecraftServer
 import net.minestom.server.item.enchant.Enchantment
@@ -19,7 +18,6 @@ import net.theevilreaper.stelaris.cli.generator.dart.util.CLASS_PROPERTIES
 import net.theevilreaper.stelaris.cli.generator.dart.util.CONSTRUCTOR_PARAMETERS
 import net.theevilreaper.stelaris.cli.util.EMPTY_STRING
 import net.theevilreaper.stelaris.cli.util.StringHelper
-import java.nio.file.Files
 import java.nio.file.Path
 
 /**

--- a/src/main/kotlin/net/theevilreaper/stelaris/cli/generator/dart/material/MaterialSubGenerator.kt
+++ b/src/main/kotlin/net/theevilreaper/stelaris/cli/generator/dart/material/MaterialSubGenerator.kt
@@ -20,10 +20,13 @@ internal object MaterialSubGenerator {
 
     fun generateBlockMaterialEnum(className: String, materials: List<Material>): ClassBuilder {
         val enumProperties = materials.map {
-            val name = escapeMinecraftPart(it.name())
-            EnumEntrySpec.builder(name)
-                .parameter(EnumParameterSpec.positional("%C", StringHelper.mapDisplayName(name)))
+            val rawName = it.name()
+            val nameWithOutMinecraftPrefix = rawName.replace("minecraft:", EMPTY_STRING)
+            val variableName = StringHelper.toLowerCamelCase(nameWithOutMinecraftPrefix)
+            val name = StringHelper.mapDisplayName(nameWithOutMinecraftPrefix)
+            EnumEntrySpec.builder(variableName)
                 .parameter(EnumParameterSpec.positional("%C", name))
+                .parameter(EnumParameterSpec.positional("%C", rawName))
                 .parameter(EnumParameterSpec.positional("%L", it.maxStackSize()))
                 .build()
         }.toSet()
@@ -45,14 +48,5 @@ internal object MaterialSubGenerator {
                     .build()
             )
         return enumFile
-    }
-
-    /**
-     * Escapes the minecraft part from the given name.
-     * @param name the name to escape
-     * @return the escaped name
-     */
-    private fun escapeMinecraftPart(name: String): String {
-        return name.replace("minecraft:", EMPTY_STRING)
     }
 }

--- a/src/main/kotlin/net/theevilreaper/stelaris/cli/generator/dart/sound/SoundEventGenerator.kt
+++ b/src/main/kotlin/net/theevilreaper/stelaris/cli/generator/dart/sound/SoundEventGenerator.kt
@@ -29,27 +29,13 @@ class SoundEventGenerator : BaseGenerator(
             val className = "${key.type.replaceFirstChar { it.uppercase() }}Sound"
             val fileName = "${key.type}_sound"
 
+            val enumEntries = value
+                .distinctBy { it.key().value().split(".").let { parts -> "${parts[1]}_${parts.last()}" } }
+                .map { buildEnumEntry(it.key()) }
+
             val enumClass = ClassSpec.enumClass(className)
                 .apply {
-                    value
-                        .distinctBy { it.key().value().split(".").let { parts -> "${parts[1]}_${parts.last()}" } }
-                        .forEach { it ->
-                            val soundKey: Key = it.key()
-                            val soundData = soundKey.value().split(".")
-                            val soundType = soundData[1]
-                            val variant = soundData.last()
-                            val soundTypeTitle = SoundHelper.refactorSoundData(soundType)
-                            val soundVariant = SoundHelper.refactorSoundData(variant)
-                            val displayName = StringHelper.mapDisplayName("$soundTypeTitle $soundVariant")
-                            val enumName = "${soundType}_$variant"
-
-                            enumProperty(
-                                EnumEntrySpec.builder(enumName)
-                                    .parameter(EnumParameterSpec.positional("%C", displayName))
-                                    .parameter(EnumParameterSpec.positional("%C", it.key().asString()))
-                                    .build()
-                            )
-                        }
+                    enumEntries.forEach { enumProperty(it) }
                 }
                 .property(
                     PropertySpec.builder("name", String::class).modifier(DartModifier.FINAL).build()
@@ -78,4 +64,20 @@ class SoundEventGenerator : BaseGenerator(
     }
 
     override fun getName(): String = "SoundTypeGenerator"
+
+    private fun buildEnumEntry(soundKey: Key): EnumEntrySpec {
+        val parts = soundKey.value().split(".")
+        require(parts.size >= 2) { "Invalid sound key: ${soundKey.value()}" }
+
+        val soundType = parts[1]
+        val variant = parts.last()
+
+        val enumName = StringHelper.toLowerCamelCase("${soundType}_${variant}")
+        val displayName = StringHelper.mapDisplayName("$soundType $variant")
+
+        return EnumEntrySpec.builder(enumName)
+            .parameter(EnumParameterSpec.positional("%C", displayName))
+            .parameter(EnumParameterSpec.positional("%C", soundKey.asString()))
+            .build()
+    }
 }

--- a/src/main/kotlin/net/theevilreaper/stelaris/cli/generator/dart/sound/SoundHelper.kt
+++ b/src/main/kotlin/net/theevilreaper/stelaris/cli/generator/dart/sound/SoundHelper.kt
@@ -2,7 +2,6 @@ package net.theevilreaper.stelaris.cli.generator.dart.sound
 
 import net.kyori.adventure.key.Key
 import net.minestom.server.sound.SoundEvent
-import net.theevilreaper.stelaris.cli.util.EMPTY_STRING
 import org.slf4j.LoggerFactory
 
 /**
@@ -33,17 +32,5 @@ internal object SoundHelper {
                 soundType to sound
             }
         }.groupBy({ it.first }, { it.second })
-    }
-
-    /**
-     * Refactors the sound data string by removing dots and capitalizing the first letter of each part.
-     * @param soundData the sound data string to refactor
-     * @return a refactored string where each part is capitalized and dots are removed
-     */
-    fun refactorSoundData(soundData: String): String {
-        val soundParts = soundData.replace("_", EMPTY_STRING).split(".")
-        return soundParts.joinToString(separator = EMPTY_STRING) { it ->
-            it.replaceFirstChar { char -> char.uppercase() }
-        }
     }
 }

--- a/src/main/kotlin/net/theevilreaper/stelaris/cli/util/StringHelper.kt
+++ b/src/main/kotlin/net/theevilreaper/stelaris/cli/util/StringHelper.kt
@@ -10,7 +10,7 @@ object StringHelper {
 
     /**
      * Converts a given string to a name which can be shown in an ui field.
-     * @param rawName the name which should be converted
+     * @param rawName the rawName which should be converted
      * @return the converted name
      */
     fun mapDisplayName(rawName: String): String {
@@ -23,5 +23,22 @@ object StringHelper {
                 char -> char.uppercase()
             }
         }
+    }
+
+    /**
+     * Converts a given string to a lower camel case string.
+     * @param input the input, which should be converted
+     * @return the converted string
+     */
+    fun toLowerCamelCase(input: String): String {
+        val parts = input
+            .lowercase()
+            .split('_')
+            .filter { it.isNotEmpty() } // removes empty segments from "__"
+
+        if (parts.isEmpty()) return ""
+
+        return parts.first() +
+                parts.drop(1).joinToString("") { it.replaceFirstChar(Char::uppercase) }
     }
 }


### PR DESCRIPTION
## Proposed changes

The Dart language wants that each enum entry name follows the `lowerCamelCase` which is not given in each case. Also some entries misses the `minecraft:`  prefix. So this pull request updates the enum entry generation to fix both issues.

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the CONTRIBUTING.md
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)