### PR TITLE
feat: Add EnchantmentGroup enumeration generation

### DIFF
--- a/src/main/kotlin/net/theevilreaper/stelaris/cli/generator/GeneratorRegistry.kt
+++ b/src/main/kotlin/net/theevilreaper/stelaris/cli/generator/GeneratorRegistry.kt
@@ -5,6 +5,7 @@ import net.theevilreaper.stelaris.cli.generator.dart.bossbar.BossBarColorGenerat
 import net.theevilreaper.stelaris.cli.generator.dart.bossbar.BossBarFlagGenerator
 import net.theevilreaper.stelaris.cli.generator.dart.bossbar.BossBarOverlayGenerator
 import net.theevilreaper.stelaris.cli.generator.dart.enchantment.EnchantmentGenerator
+import net.theevilreaper.stelaris.cli.generator.dart.enchantment.EnchantmentGroupGenerator
 import net.theevilreaper.stelaris.cli.generator.dart.sound.SoundEventGenerator
 import net.theevilreaper.stelaris.cli.generator.dart.sound.SoundSourceGenerator
 import net.theevilreaper.stelaris.cli.generator.dart.sound.SoundTypeGenerator
@@ -23,6 +24,7 @@ class GeneratorRegistry {
         BossBarFlagGenerator(),
         BossBarOverlayGenerator(),
         EnchantmentGenerator(),
+        EnchantmentGroupGenerator(),
         EntityTypeGenerator(),
         FrameTypeGenerator(),
         MaterialGenerator(),

--- a/src/main/kotlin/net/theevilreaper/stelaris/cli/generator/dart/enchantment/EnchantmentGroup.kt
+++ b/src/main/kotlin/net/theevilreaper/stelaris/cli/generator/dart/enchantment/EnchantmentGroup.kt
@@ -6,7 +6,7 @@ enum class EnchantmentGroup(val classPart: String, val keywords: Set<String>) {
     ARMOR("armor", setOf("armor", "foot_armor", "head_armor", "leg_armor", "equippable")),
     WEAPON("weapon", setOf("sword", "bow", "trident", "mace", "weapon", "fire_aspect", "sharp_weapon", "crossbow")),
     TOOL("tool", setOf("mining", "mining_loot", "fishing")),
-    MISC("meta", setOf("vanishing", "durability"))
+    META("meta", setOf("vanishing", "durability"))
     ;
 
     companion object {

--- a/src/main/kotlin/net/theevilreaper/stelaris/cli/generator/dart/enchantment/EnchantmentGroupGenerator.kt
+++ b/src/main/kotlin/net/theevilreaper/stelaris/cli/generator/dart/enchantment/EnchantmentGroupGenerator.kt
@@ -1,0 +1,54 @@
+package net.theevilreaper.stelaris.cli.generator.dart.enchantment
+
+import net.theevilreaper.dartpoet.DartFile
+import net.theevilreaper.dartpoet.DartModifier
+import net.theevilreaper.dartpoet.clazz.ClassSpec
+import net.theevilreaper.dartpoet.constructor.ConstructorSpec
+import net.theevilreaper.dartpoet.enum.EnumEntrySpec
+import net.theevilreaper.dartpoet.enum.parameter.EnumParameterSpec
+import net.theevilreaper.dartpoet.parameter.ParameterSpec
+import net.theevilreaper.dartpoet.property.PropertySpec
+import net.theevilreaper.stelaris.cli.generator.BaseGenerator
+import net.theevilreaper.stelaris.cli.util.StringHelper
+import java.nio.file.Path
+
+class EnchantmentGroupGenerator: BaseGenerator(
+    packageName = "enchantment",
+    className = "EnchantmentGroup"
+) {
+
+    override fun generate(javaPath: Path) {
+        val enchantmentFolder = javaPath.resolve(packageName)
+        checkPackageFolder(javaPath, packageName)
+
+        val enumClass = ClassSpec.enumClass(className)
+            .apply {
+                EnchantmentGroup.entries.map { entry ->
+                    enumProperty(EnumEntrySpec
+                        .builder(entry.name.lowercase())
+                        .parameter(EnumParameterSpec.positional("%C", StringHelper.mapDisplayName(entry.classPart)))
+                        .build()
+                    )
+                }
+            }
+            .property(PropertySpec.builder("displayName", String::class)
+                .modifier(DartModifier.FINAL)
+                .build()
+            )
+            .constructor(
+                ConstructorSpec.builder(className)
+                    .modifier(DartModifier.CONST)
+                    .parameter(ParameterSpec.positional("displayName").build())
+                    .build()
+            )
+            .build()
+
+        val classFile = DartFile.builder("enchantment_group")
+            .type(enumClass)
+            .build();
+
+        classFile.write(enchantmentFolder)
+    }
+
+    override fun getName(): String = "EnchantmentGroupGenerator"
+}

--- a/src/main/kotlin/net/theevilreaper/stelaris/cli/generator/dart/enchantment/EnchantmentGroupGenerator.kt
+++ b/src/main/kotlin/net/theevilreaper/stelaris/cli/generator/dart/enchantment/EnchantmentGroupGenerator.kt
@@ -45,6 +45,10 @@ class EnchantmentGroupGenerator: BaseGenerator(
 
         val classFile = DartFile.builder("enchantment_group")
             .type(enumClass)
+            .doc("Represents a category of enchantments based on their primary application")
+            .doc("")
+            .doc("Enchantments are grouped by the type of items they can be applied to,")
+            .doc("making it easier to filter and organize them by use case.")
             .build();
 
         classFile.write(enchantmentFolder)

--- a/src/test/kotlin/net/theevilreaper/stelaris/cli/generator/dart/enchantment/EnchantmentGroupGeneratorTest.kt
+++ b/src/test/kotlin/net/theevilreaper/stelaris/cli/generator/dart/enchantment/EnchantmentGroupGeneratorTest.kt
@@ -1,0 +1,48 @@
+package net.theevilreaper.stelaris.cli.generator.dart.enchantment
+
+import net.theevilreaper.stelaris.cli.generator.GenerationTestBase
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+
+class EnchantmentGroupGeneratorTest : GenerationTestBase() {
+
+    @Test
+    fun `test enchantment group enumeration generation`() {
+        val enchantmentGroupGenerator = EnchantmentGroupGenerator()
+        enchantmentGroupGenerator.generate(generationPath)
+
+        val generatedFiles = generationPath.resolve("enchantment").toFile().listFiles()
+        assertNotNull(generatedFiles)
+        assertEquals(1, generatedFiles!!.size, "Expected exactly one file to be generated")
+
+        val generatedFile = generatedFiles.first()
+
+        assertEquals(
+            "enchantment_group.dart",
+            generatedFile.absoluteFile.name,
+            "Expected generated file to be named 'enchantment_group.dart'"
+        )
+
+        assertEquals(
+            """
+            /// Represents a category of enchantments based on their primary application
+            ///
+            /// Enchantments are grouped by the type of items they can be applied to,
+            /// making it easier to filter and organize them by use case.
+            enum EnchantmentGroup {
+
+              armor('Armor'),
+              weapon('Weapon'),
+              tool('Tool'),
+              meta('Meta');
+
+              final String displayName;
+
+              const EnchantmentGroup(this.displayName);
+
+            }
+        """.trimIndent(),
+            generatedFile.readText(), "Generated Dart class does not match expected content"
+        )
+    }
+}


### PR DESCRIPTION
## Proposed changes

The project uses an `EnchantmentGroup` enumeration internally to sort enchantments by their group. Due to its internal usage, this structure is currently not available on the Flutter side. This pull request adds the generation of this file for Dart.
In the future, we can enhance the enchantment generation to provide additional methods/functions for sorting, filtering, etc.

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the CONTRIBUTING.md
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)