### PR TITLE
feat(material): add new sub types

### DIFF
--- a/src/main/kotlin/net/theevilreaper/stelaris/cli/generator/dart/MaterialGenerator.kt
+++ b/src/main/kotlin/net/theevilreaper/stelaris/cli/generator/dart/MaterialGenerator.kt
@@ -1,11 +1,13 @@
 package net.theevilreaper.stelaris.cli.generator.dart
 
+import net.minestom.server.component.DataComponents
 import net.minestom.server.item.Material
 import net.theevilreaper.dartpoet.DartFile
 import net.theevilreaper.dartpoet.clazz.ClassSpec
 import net.theevilreaper.stelaris.cli.generator.BaseGenerator
 import net.theevilreaper.stelaris.cli.generator.dart.material.MaterialSubGenerator
 import net.theevilreaper.stelaris.cli.generator.dart.material.MaterialSubType
+import net.theevilreaper.stelaris.cli.util.StringHelper
 import java.nio.file.Path
 
 /**
@@ -50,14 +52,21 @@ class MaterialGenerator : BaseGenerator(
     }
 
     private fun mapTypeToBoolean(subType: MaterialSubType, material: Material): Boolean {
+        val prototype = material.prototype()
         return when (subType) {
-            MaterialSubType.BLOCK -> material.isBlock
-            MaterialSubType.ARMOR -> material.isArmor
+            MaterialSubType.BLOCK -> material.block() != null
+            MaterialSubType.ARMOR -> material.equipmentSlot()?.isArmor == true
+            MaterialSubType.TOOL -> prototype.has(DataComponents.TOOL)
+            MaterialSubType.WEAPON -> prototype.has(DataComponents.WEAPON)
+            MaterialSubType.FOOD -> prototype.has(DataComponents.FOOD)
+            MaterialSubType.DYE -> prototype.has(DataComponents.DYE)
+            MaterialSubType.SPAWN_EGG -> material.name().endsWith("_spawn_egg")
         }
     }
 
     private fun translateEnumClassName(materialSubType: MaterialSubType): String {
-        return "${materialSubType.type.replaceFirstChar { it.uppercase() }}$materialClassName"
+        val prefix = StringHelper.toLowerCamelCase(materialSubType.type).replaceFirstChar { it.uppercase() }
+        return "$prefix$materialClassName"
     }
 
     private inline fun generateItemEnum(

--- a/src/main/kotlin/net/theevilreaper/stelaris/cli/generator/dart/material/MaterialSubType.kt
+++ b/src/main/kotlin/net/theevilreaper/stelaris/cli/generator/dart/material/MaterialSubType.kt
@@ -12,4 +12,9 @@ enum class MaterialSubType(val type: String) {
 
     BLOCK("block"),
     ARMOR("armor"),
+    TOOL("tool"),
+    WEAPON("weapon"),
+    FOOD("food"),
+    DYE("dye"),
+    SPAWN_EGG("spawn_egg")
 }

--- a/src/test/kotlin/net/theevilreaper/stelaris/cli/generator/dart/MaterialGeneratorTest.kt
+++ b/src/test/kotlin/net/theevilreaper/stelaris/cli/generator/dart/MaterialGeneratorTest.kt
@@ -1,5 +1,6 @@
 package net.theevilreaper.stelaris.cli.generator.dart
 
+import net.minestom.server.item.Material
 import net.minestom.testing.Env
 import net.minestom.testing.extension.MicrotusExtension
 import net.theevilreaper.stelaris.cli.generator.GenerationTestBase
@@ -24,13 +25,26 @@ class MaterialGeneratorTest : GenerationTestBase() {
 
         val generatedFiles = materialsFolder.listFiles()
         assertNotNull(generatedFiles)
-        assertTrue(generatedFiles!!.isNotEmpty(), "Expected generated material files to not be empty")
+        assertEquals(7, generatedFiles!!.size, "Expected exactly 7 material files to be generated")
 
-        val sampleFile = generatedFiles.first()
-        assertTrue(sampleFile.name.endsWith(".dart"), "Generated file should be a Dart file")
-        val content = sampleFile.readText()
-        assertTrue(content.contains("final String displayName;"), "Generated material file should declare displayName property")
-        assertTrue(content.contains("final String material;"), "Generated material file should declare material property")
-        assertTrue(content.contains("final int maxStackSize;"), "Generated material file should declare maxStackSize property")
+        val expectedFiles = mapOf(
+            "block_materials.dart" to "enum BlockMaterial",
+            "armor_materials.dart" to "enum ArmorMaterial",
+            "tool_materials.dart" to "enum ToolMaterial",
+            "weapon_materials.dart" to "enum WeaponMaterial",
+            "food_materials.dart" to "enum FoodMaterial",
+            "dye_materials.dart" to "enum DyeMaterial",
+            "spawn_egg_materials.dart" to "enum SpawnEggMaterial"
+        )
+
+        for ((fileName, expectedEnum) in expectedFiles) {
+            val file = materialsFolder.resolve(fileName)
+            assertTrue(file.exists(), "Expected $fileName to exist")
+            val content = file.readText()
+            assertTrue(content.contains(expectedEnum), "Expected $fileName to contain '$expectedEnum'")
+            assertTrue(content.contains("final String displayName;"), "$fileName should declare displayName property")
+            assertTrue(content.contains("final String material;"), "$fileName should declare material property")
+            assertTrue(content.contains("final int maxStackSize;"), "$fileName should declare maxStackSize property")
+        }
     }
 }


### PR DESCRIPTION
## Proposed changes

The generation of the `Material` enumeration results in a large enum definition. While this is generally fine, it is not ideal when additional logic, such as search functionality, is required. Large enums can also become difficult to maintain. Therefore, this pull request adjusts the generation and introduces separate material definitions.

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the CONTRIBUTING.md
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)