### PR TITLE
feat(generator): add registry enum generation

### DIFF
--- a/src/main/kotlin/net/theevilreaper/stelaris/cli/generator/GeneratorRegistry.kt
+++ b/src/main/kotlin/net/theevilreaper/stelaris/cli/generator/GeneratorRegistry.kt
@@ -1,16 +1,17 @@
 package net.theevilreaper.stelaris.cli.generator
 
 import net.theevilreaper.stelaris.cli.generator.dart.*
+import net.theevilreaper.stelaris.cli.generator.dart.banner.BannerPatternGenerator
 import net.theevilreaper.stelaris.cli.generator.dart.bossbar.BossBarColorGenerator
 import net.theevilreaper.stelaris.cli.generator.dart.bossbar.BossBarFlagGenerator
 import net.theevilreaper.stelaris.cli.generator.dart.bossbar.BossBarOverlayGenerator
 import net.theevilreaper.stelaris.cli.generator.dart.color.DyeColorGenerator
+import net.theevilreaper.stelaris.cli.generator.dart.damage.DamageTypeGenerator
 import net.theevilreaper.stelaris.cli.generator.dart.enchantment.EnchantmentGenerator
 import net.theevilreaper.stelaris.cli.generator.dart.enchantment.EnchantmentGroupGenerator
 import net.theevilreaper.stelaris.cli.generator.dart.entity.variant.EntityVariantGenerator
-import net.theevilreaper.stelaris.cli.generator.dart.item.FireworkShapeGenerator
-import net.theevilreaper.stelaris.cli.generator.dart.item.ItemRarityGenerator
-import net.theevilreaper.stelaris.cli.generator.dart.item.MapPostProcessingGenerator
+import net.theevilreaper.stelaris.cli.generator.dart.item.*
+import net.theevilreaper.stelaris.cli.generator.dart.painting.PaintingVariantGenerator
 import net.theevilreaper.stelaris.cli.generator.dart.sound.SoundEventGenerator
 import net.theevilreaper.stelaris.cli.generator.dart.sound.SoundSourceGenerator
 import net.theevilreaper.stelaris.cli.generator.dart.sound.SoundTypeGenerator
@@ -26,9 +27,11 @@ import net.theevilreaper.stelaris.cli.generator.dart.villager.VillagerTypeGenera
 class GeneratorRegistry {
 
     private val generators: Set<Generator> = setOf(
+        BannerPatternGenerator(),
         BossBarColorGenerator(),
         BossBarFlagGenerator(),
         BossBarOverlayGenerator(),
+        DamageTypeGenerator(),
         DyeColorGenerator(),
         EnchantmentGenerator(),
         EnchantmentGroupGenerator(),
@@ -36,12 +39,17 @@ class GeneratorRegistry {
         EntityVariantGenerator(),
         FireworkShapeGenerator(),
         FrameTypeGenerator(),
+        InstrumentGenerator(),
+        ItemRarityGenerator(),
+        JukeboxSongGenerator(),
         MaterialGenerator(),
         MapPostProcessingGenerator(),
+        PaintingVariantGenerator(),
         SoundSourceGenerator(),
         SoundEventGenerator(),
         SoundTypeGenerator(),
-        ItemRarityGenerator(),
+        TrimMaterialGenerator(),
+        TrimPatternGenerator(),
         VillagerTypeGenerator()
     )
 

--- a/src/main/kotlin/net/theevilreaper/stelaris/cli/generator/dart/banner/BannerPatternGenerator.kt
+++ b/src/main/kotlin/net/theevilreaper/stelaris/cli/generator/dart/banner/BannerPatternGenerator.kt
@@ -1,0 +1,80 @@
+package net.theevilreaper.stelaris.cli.generator.dart.banner
+
+import net.minestom.server.instance.block.banner.BannerPattern
+import net.theevilreaper.dartpoet.DartFile
+import net.theevilreaper.dartpoet.DartModifier
+import net.theevilreaper.dartpoet.clazz.ClassSpec
+import net.theevilreaper.dartpoet.constructor.ConstructorSpec
+import net.theevilreaper.dartpoet.enum.EnumEntrySpec
+import net.theevilreaper.dartpoet.enum.parameter.EnumParameterSpec
+import net.theevilreaper.dartpoet.parameter.ParameterSpec
+import net.theevilreaper.dartpoet.property.PropertySpec
+import net.theevilreaper.stelaris.cli.generator.BaseGenerator
+import net.theevilreaper.stelaris.cli.util.EMPTY_STRING
+import net.theevilreaper.stelaris.cli.util.StringHelper
+import java.nio.file.Path
+
+/**
+ * Generates the [BannerPattern] enum for dart.
+ * @version 1.0.0
+ * @since 1.0.0
+ * @author theEvilReaper
+ */
+class BannerPatternGenerator : BaseGenerator(
+    className = "BannerPattern",
+    packageName = "banner",
+) {
+
+    override fun generate(outputPath: Path) {
+        val folder = checkPackageFolder(outputPath, packageName)
+        val registry = BannerPattern.createDefaultRegistry()
+        val enumEntries = mutableListOf<EnumEntrySpec>()
+
+        val sortedEntries = registry.values().sortedBy { registry.getKey(it)?.name() ?: EMPTY_STRING }
+
+        for (pattern in sortedEntries) {
+            val key = registry.getKey(pattern)?.name() ?: continue
+            val nameWithoutPrefix = key.replace("minecraft:", EMPTY_STRING)
+            val variableName = StringHelper.toLowerCamelCase(nameWithoutPrefix)
+            val displayName = StringHelper.mapDisplayName(nameWithoutPrefix)
+
+            enumEntries.add(
+                EnumEntrySpec.builder(variableName)
+                    .parameter(EnumParameterSpec.positional("%C", displayName))
+                    .parameter(EnumParameterSpec.positional("%C", key))
+                    .parameter(EnumParameterSpec.positional("%C", pattern.assetId().asString()))
+                    .parameter(EnumParameterSpec.positional("%C", pattern.translationKey()))
+                    .build()
+            )
+        }
+
+        val enumClass = ClassSpec.enumClass(className)
+            .enumProperties(*enumEntries.toTypedArray())
+            .properties(
+                PropertySpec.builder("displayName", String::class).modifier(DartModifier.FINAL).build(),
+                PropertySpec.builder("key", String::class).modifier(DartModifier.FINAL).build(),
+                PropertySpec.builder("assetId", String::class).modifier(DartModifier.FINAL).build(),
+                PropertySpec.builder("translationKey", String::class).modifier(DartModifier.FINAL).build()
+            )
+            .constructor(
+                ConstructorSpec.builder(className)
+                    .modifier(DartModifier.CONST)
+                    .parameters(
+                        ParameterSpec.positional("displayName").build(),
+                        ParameterSpec.positional("key").build(),
+                        ParameterSpec.positional("assetId").build(),
+                        ParameterSpec.positional("translationKey").build()
+                    )
+                    .build()
+            )
+            .build()
+
+        val file = DartFile.builder("banner_pattern")
+            .doc("The file is generated. Don't change anything here")
+            .type(enumClass)
+            .build()
+        file.write(folder)
+    }
+
+    override fun getName() = "BannerPatternGenerator"
+}

--- a/src/main/kotlin/net/theevilreaper/stelaris/cli/generator/dart/damage/DamageTypeGenerator.kt
+++ b/src/main/kotlin/net/theevilreaper/stelaris/cli/generator/dart/damage/DamageTypeGenerator.kt
@@ -1,0 +1,82 @@
+package net.theevilreaper.stelaris.cli.generator.dart.damage
+
+import net.minestom.server.entity.damage.DamageType
+import net.theevilreaper.dartpoet.DartFile
+import net.theevilreaper.dartpoet.DartModifier
+import net.theevilreaper.dartpoet.clazz.ClassSpec
+import net.theevilreaper.dartpoet.constructor.ConstructorSpec
+import net.theevilreaper.dartpoet.enum.EnumEntrySpec
+import net.theevilreaper.dartpoet.enum.parameter.EnumParameterSpec
+import net.theevilreaper.dartpoet.parameter.ParameterSpec
+import net.theevilreaper.dartpoet.property.PropertySpec
+import net.theevilreaper.stelaris.cli.generator.BaseGenerator
+import net.theevilreaper.stelaris.cli.util.EMPTY_STRING
+import net.theevilreaper.stelaris.cli.util.StringHelper
+import java.nio.file.Path
+
+/**
+ * Generates the [DamageType] enum for dart.
+ * @version 1.0.0
+ * @since 1.0.0
+ * @author theEvilReaper
+ */
+class DamageTypeGenerator : BaseGenerator(
+    className = "DamageType",
+    packageName = "damage",
+) {
+
+    override fun generate(outputPath: Path) {
+        val folder = checkPackageFolder(outputPath, packageName)
+        val registry = DamageType.createDefaultRegistry()
+        val enumEntries = mutableListOf<EnumEntrySpec>()
+
+        val distinctEntries = registry.values()
+            .distinctBy { registry.getKey(it)?.name() }
+            .sortedBy { registry.getKey(it)?.name() ?: EMPTY_STRING }
+
+        for (damageType in distinctEntries) {
+            val key = registry.getKey(damageType)?.name() ?: continue
+            val nameWithoutPrefix = key.replace("minecraft:", EMPTY_STRING)
+            val variableName = StringHelper.toLowerCamelCase(nameWithoutPrefix)
+            val displayName = StringHelper.mapDisplayName(nameWithoutPrefix)
+
+            enumEntries.add(
+                EnumEntrySpec.builder(variableName)
+                    .parameter(EnumParameterSpec.positional("%C", displayName))
+                    .parameter(EnumParameterSpec.positional("%C", key))
+                    .parameter(EnumParameterSpec.positional("%C", damageType.messageId()))
+                    .parameter(EnumParameterSpec.positional("%L", damageType.exhaustion().toString().toDouble()))
+                    .build()
+            )
+        }
+
+        val enumClass = ClassSpec.enumClass(className)
+            .enumProperties(*enumEntries.toTypedArray())
+            .properties(
+                PropertySpec.builder("displayName", String::class).modifier(DartModifier.FINAL).build(),
+                PropertySpec.builder("key", String::class).modifier(DartModifier.FINAL).build(),
+                PropertySpec.builder("messageId", String::class).modifier(DartModifier.FINAL).build(),
+                PropertySpec.builder("exhaustion", Double::class).modifier(DartModifier.FINAL).build()
+            )
+            .constructor(
+                ConstructorSpec.builder(className)
+                    .modifier(DartModifier.CONST)
+                    .parameters(
+                        ParameterSpec.positional("displayName").build(),
+                        ParameterSpec.positional("key").build(),
+                        ParameterSpec.positional("messageId").build(),
+                        ParameterSpec.positional("exhaustion").build()
+                    )
+                    .build()
+            )
+            .build()
+
+        val file = DartFile.builder("damage_type")
+            .doc("The file is generated. Don't change anything here")
+            .type(enumClass)
+            .build()
+        file.write(folder)
+    }
+
+    override fun getName() = "DamageTypeGenerator"
+}

--- a/src/main/kotlin/net/theevilreaper/stelaris/cli/generator/dart/item/InstrumentGenerator.kt
+++ b/src/main/kotlin/net/theevilreaper/stelaris/cli/generator/dart/item/InstrumentGenerator.kt
@@ -1,0 +1,80 @@
+package net.theevilreaper.stelaris.cli.generator.dart.item
+
+import net.minestom.server.item.instrument.Instrument
+import net.theevilreaper.dartpoet.DartFile
+import net.theevilreaper.dartpoet.DartModifier
+import net.theevilreaper.dartpoet.clazz.ClassSpec
+import net.theevilreaper.dartpoet.constructor.ConstructorSpec
+import net.theevilreaper.dartpoet.enum.EnumEntrySpec
+import net.theevilreaper.dartpoet.enum.parameter.EnumParameterSpec
+import net.theevilreaper.dartpoet.parameter.ParameterSpec
+import net.theevilreaper.dartpoet.property.PropertySpec
+import net.theevilreaper.stelaris.cli.generator.BaseGenerator
+import net.theevilreaper.stelaris.cli.util.EMPTY_STRING
+import net.theevilreaper.stelaris.cli.util.StringHelper
+import java.nio.file.Path
+
+/**
+ * Generates the [Instrument] enum for dart.
+ * @version 1.0.0
+ * @since 1.0.0
+ * @author theEvilReaper
+ */
+class InstrumentGenerator : BaseGenerator(
+    className = "Instrument",
+    packageName = "item",
+) {
+
+    override fun generate(outputPath: Path) {
+        val folder = checkPackageFolder(outputPath, packageName)
+        val registry = Instrument.createDefaultRegistry()
+        val enumEntries = mutableListOf<EnumEntrySpec>()
+
+        val sortedEntries = registry.values().sortedBy { registry.getKey(it)?.name() ?: EMPTY_STRING }
+
+        for (instrument in sortedEntries) {
+            val key = registry.getKey(instrument)?.name() ?: continue
+            val nameWithoutPrefix = key.replace("minecraft:", EMPTY_STRING)
+            val variableName = StringHelper.toLowerCamelCase(nameWithoutPrefix)
+            val displayName = StringHelper.mapDisplayName(nameWithoutPrefix)
+
+            enumEntries.add(
+                EnumEntrySpec.builder(variableName)
+                    .parameter(EnumParameterSpec.positional("%C", displayName))
+                    .parameter(EnumParameterSpec.positional("%C", key))
+                    .parameter(EnumParameterSpec.positional("%L", instrument.range()))
+                    .parameter(EnumParameterSpec.positional("%L", instrument.useDuration()))
+                    .build()
+            )
+        }
+
+        val enumClass = ClassSpec.enumClass(className)
+            .enumProperties(*enumEntries.toTypedArray())
+            .properties(
+                PropertySpec.builder("displayName", String::class).modifier(DartModifier.FINAL).build(),
+                PropertySpec.builder("key", String::class).modifier(DartModifier.FINAL).build(),
+                PropertySpec.builder("range", Double::class).modifier(DartModifier.FINAL).build(),
+                PropertySpec.builder("useDuration", Double::class).modifier(DartModifier.FINAL).build()
+            )
+            .constructor(
+                ConstructorSpec.builder(className)
+                    .modifier(DartModifier.CONST)
+                    .parameters(
+                        ParameterSpec.positional("displayName").build(),
+                        ParameterSpec.positional("key").build(),
+                        ParameterSpec.positional("range").build(),
+                        ParameterSpec.positional("useDuration").build()
+                    )
+                    .build()
+            )
+            .build()
+
+        val file = DartFile.builder("instrument")
+            .doc("The file is generated. Don't change anything here")
+            .type(enumClass)
+            .build()
+        file.write(folder)
+    }
+
+    override fun getName() = "InstrumentGenerator"
+}

--- a/src/main/kotlin/net/theevilreaper/stelaris/cli/generator/dart/item/JukeboxSongGenerator.kt
+++ b/src/main/kotlin/net/theevilreaper/stelaris/cli/generator/dart/item/JukeboxSongGenerator.kt
@@ -1,0 +1,80 @@
+package net.theevilreaper.stelaris.cli.generator.dart.item
+
+import net.minestom.server.instance.block.jukebox.JukeboxSong
+import net.theevilreaper.dartpoet.DartFile
+import net.theevilreaper.dartpoet.DartModifier
+import net.theevilreaper.dartpoet.clazz.ClassSpec
+import net.theevilreaper.dartpoet.constructor.ConstructorSpec
+import net.theevilreaper.dartpoet.enum.EnumEntrySpec
+import net.theevilreaper.dartpoet.enum.parameter.EnumParameterSpec
+import net.theevilreaper.dartpoet.parameter.ParameterSpec
+import net.theevilreaper.dartpoet.property.PropertySpec
+import net.theevilreaper.stelaris.cli.generator.BaseGenerator
+import net.theevilreaper.stelaris.cli.util.EMPTY_STRING
+import net.theevilreaper.stelaris.cli.util.StringHelper
+import java.nio.file.Path
+
+/**
+ * Generates the [JukeboxSong] enum for dart.
+ * @version 1.0.0
+ * @since 1.0.0
+ * @author theEvilReaper
+ */
+class JukeboxSongGenerator : BaseGenerator(
+    className = "JukeboxSong",
+    packageName = "item",
+) {
+
+    override fun generate(outputPath: Path) {
+        val folder = checkPackageFolder(outputPath, packageName)
+        val registry = JukeboxSong.createDefaultRegistry()
+        val enumEntries = mutableListOf<EnumEntrySpec>()
+
+        val sortedEntries = registry.values().sortedBy { registry.getKey(it)?.name() ?: EMPTY_STRING }
+
+        for (song in sortedEntries) {
+            val key = registry.getKey(song)?.name() ?: continue
+            val nameWithoutPrefix = key.replace("minecraft:", EMPTY_STRING)
+            val variableName = StringHelper.toLowerCamelCase(nameWithoutPrefix)
+            val displayName = StringHelper.mapDisplayName(nameWithoutPrefix)
+
+            enumEntries.add(
+                EnumEntrySpec.builder(variableName)
+                    .parameter(EnumParameterSpec.positional("%C", displayName))
+                    .parameter(EnumParameterSpec.positional("%C", key))
+                    .parameter(EnumParameterSpec.positional("%L", song.lengthInSeconds().toString().toDouble()))
+                    .parameter(EnumParameterSpec.positional("%L", song.comparatorOutput()))
+                    .build()
+            )
+        }
+
+        val enumClass = ClassSpec.enumClass(className)
+            .enumProperties(*enumEntries.toTypedArray())
+            .properties(
+                PropertySpec.builder("displayName", String::class).modifier(DartModifier.FINAL).build(),
+                PropertySpec.builder("key", String::class).modifier(DartModifier.FINAL).build(),
+                PropertySpec.builder("lengthInSeconds", Double::class).modifier(DartModifier.FINAL).build(),
+                PropertySpec.builder("comparatorOutput", Int::class).modifier(DartModifier.FINAL).build()
+            )
+            .constructor(
+                ConstructorSpec.builder(className)
+                    .modifier(DartModifier.CONST)
+                    .parameters(
+                        ParameterSpec.positional("displayName").build(),
+                        ParameterSpec.positional("key").build(),
+                        ParameterSpec.positional("lengthInSeconds").build(),
+                        ParameterSpec.positional("comparatorOutput").build()
+                    )
+                    .build()
+            )
+            .build()
+
+        val file = DartFile.builder("jukebox_song")
+            .doc("The file is generated. Don't change anything here")
+            .type(enumClass)
+            .build()
+        file.write(folder)
+    }
+
+    override fun getName() = "JukeboxSongGenerator"
+}

--- a/src/main/kotlin/net/theevilreaper/stelaris/cli/generator/dart/item/TrimMaterialGenerator.kt
+++ b/src/main/kotlin/net/theevilreaper/stelaris/cli/generator/dart/item/TrimMaterialGenerator.kt
@@ -1,0 +1,77 @@
+package net.theevilreaper.stelaris.cli.generator.dart.item
+
+import net.minestom.server.item.armor.TrimMaterial
+import net.theevilreaper.dartpoet.DartFile
+import net.theevilreaper.dartpoet.DartModifier
+import net.theevilreaper.dartpoet.clazz.ClassSpec
+import net.theevilreaper.dartpoet.constructor.ConstructorSpec
+import net.theevilreaper.dartpoet.enum.EnumEntrySpec
+import net.theevilreaper.dartpoet.enum.parameter.EnumParameterSpec
+import net.theevilreaper.dartpoet.parameter.ParameterSpec
+import net.theevilreaper.dartpoet.property.PropertySpec
+import net.theevilreaper.stelaris.cli.generator.BaseGenerator
+import net.theevilreaper.stelaris.cli.util.EMPTY_STRING
+import net.theevilreaper.stelaris.cli.util.StringHelper
+import java.nio.file.Path
+
+/**
+ * Generates the [TrimMaterial] enum for dart.
+ * @version 1.0.0
+ * @since 1.0.0
+ * @author theEvilReaper
+ */
+class TrimMaterialGenerator : BaseGenerator(
+    className = "TrimMaterial",
+    packageName = "item",
+) {
+
+    override fun generate(outputPath: Path) {
+        val folder = checkPackageFolder(outputPath, packageName)
+        val registry = TrimMaterial.createDefaultRegistry()
+        val enumEntries = mutableListOf<EnumEntrySpec>()
+
+        val sortedEntries = registry.values().sortedBy { registry.getKey(it)?.name() ?: EMPTY_STRING }
+
+        for (material in sortedEntries) {
+            val key = registry.getKey(material)?.name() ?: continue
+            val nameWithoutPrefix = key.replace("minecraft:", EMPTY_STRING)
+            val variableName = StringHelper.toLowerCamelCase(nameWithoutPrefix)
+            val displayName = StringHelper.mapDisplayName(nameWithoutPrefix)
+
+            enumEntries.add(
+                EnumEntrySpec.builder(variableName)
+                    .parameter(EnumParameterSpec.positional("%C", displayName))
+                    .parameter(EnumParameterSpec.positional("%C", key))
+                    .parameter(EnumParameterSpec.positional("%C", material.assetName()))
+                    .build()
+            )
+        }
+
+        val enumClass = ClassSpec.enumClass(className)
+            .enumProperties(*enumEntries.toTypedArray())
+            .properties(
+                PropertySpec.builder("displayName", String::class).modifier(DartModifier.FINAL).build(),
+                PropertySpec.builder("key", String::class).modifier(DartModifier.FINAL).build(),
+                PropertySpec.builder("assetId", String::class).modifier(DartModifier.FINAL).build()
+            )
+            .constructor(
+                ConstructorSpec.builder(className)
+                    .modifier(DartModifier.CONST)
+                    .parameters(
+                        ParameterSpec.positional("displayName").build(),
+                        ParameterSpec.positional("key").build(),
+                        ParameterSpec.positional("assetId").build()
+                    )
+                    .build()
+            )
+            .build()
+
+        val file = DartFile.builder("trim_material")
+            .doc("The file is generated. Don't change anything here")
+            .type(enumClass)
+            .build()
+        file.write(folder)
+    }
+
+    override fun getName() = "TrimMaterialGenerator"
+}

--- a/src/main/kotlin/net/theevilreaper/stelaris/cli/generator/dart/item/TrimPatternGenerator.kt
+++ b/src/main/kotlin/net/theevilreaper/stelaris/cli/generator/dart/item/TrimPatternGenerator.kt
@@ -1,0 +1,80 @@
+package net.theevilreaper.stelaris.cli.generator.dart.item
+
+import net.minestom.server.item.armor.TrimPattern
+import net.theevilreaper.dartpoet.DartFile
+import net.theevilreaper.dartpoet.DartModifier
+import net.theevilreaper.dartpoet.clazz.ClassSpec
+import net.theevilreaper.dartpoet.constructor.ConstructorSpec
+import net.theevilreaper.dartpoet.enum.EnumEntrySpec
+import net.theevilreaper.dartpoet.enum.parameter.EnumParameterSpec
+import net.theevilreaper.dartpoet.parameter.ParameterSpec
+import net.theevilreaper.dartpoet.property.PropertySpec
+import net.theevilreaper.stelaris.cli.generator.BaseGenerator
+import net.theevilreaper.stelaris.cli.util.EMPTY_STRING
+import net.theevilreaper.stelaris.cli.util.StringHelper
+import java.nio.file.Path
+
+/**
+ * Generates the [TrimPattern] enum for dart.
+ * @version 1.0.0
+ * @since 1.0.0
+ * @author theEvilReaper
+ */
+class TrimPatternGenerator : BaseGenerator(
+    className = "TrimPattern",
+    packageName = "item",
+) {
+
+    override fun generate(outputPath: Path) {
+        val folder = checkPackageFolder(outputPath, packageName)
+        val registry = TrimPattern.createDefaultRegistry()
+        val enumEntries = mutableListOf<EnumEntrySpec>()
+
+        val sortedEntries = registry.values().sortedBy { registry.getKey(it)?.name() ?: EMPTY_STRING }
+
+        for (pattern in sortedEntries) {
+            val key = registry.getKey(pattern)?.name() ?: continue
+            val nameWithoutPrefix = key.replace("minecraft:", EMPTY_STRING)
+            val variableName = StringHelper.toLowerCamelCase(nameWithoutPrefix)
+            val displayName = StringHelper.mapDisplayName(nameWithoutPrefix)
+
+            enumEntries.add(
+                EnumEntrySpec.builder(variableName)
+                    .parameter(EnumParameterSpec.positional("%C", displayName))
+                    .parameter(EnumParameterSpec.positional("%C", key))
+                    .parameter(EnumParameterSpec.positional("%C", pattern.assetId().asString()))
+                    .parameter(EnumParameterSpec.positional("%L", pattern.isDecal))
+                    .build()
+            )
+        }
+
+        val enumClass = ClassSpec.enumClass(className)
+            .enumProperties(*enumEntries.toTypedArray())
+            .properties(
+                PropertySpec.builder("displayName", String::class).modifier(DartModifier.FINAL).build(),
+                PropertySpec.builder("key", String::class).modifier(DartModifier.FINAL).build(),
+                PropertySpec.builder("assetId", String::class).modifier(DartModifier.FINAL).build(),
+                PropertySpec.builder("decal", Boolean::class).modifier(DartModifier.FINAL).build()
+            )
+            .constructor(
+                ConstructorSpec.builder(className)
+                    .modifier(DartModifier.CONST)
+                    .parameters(
+                        ParameterSpec.positional("displayName").build(),
+                        ParameterSpec.positional("key").build(),
+                        ParameterSpec.positional("assetId").build(),
+                        ParameterSpec.positional("decal").build()
+                    )
+                    .build()
+            )
+            .build()
+
+        val file = DartFile.builder("trim_pattern")
+            .doc("The file is generated. Don't change anything here")
+            .type(enumClass)
+            .build()
+        file.write(folder)
+    }
+
+    override fun getName() = "TrimPatternGenerator"
+}

--- a/src/main/kotlin/net/theevilreaper/stelaris/cli/generator/dart/painting/PaintingVariantGenerator.kt
+++ b/src/main/kotlin/net/theevilreaper/stelaris/cli/generator/dart/painting/PaintingVariantGenerator.kt
@@ -1,0 +1,83 @@
+package net.theevilreaper.stelaris.cli.generator.dart.painting
+
+import net.minestom.server.entity.metadata.other.PaintingVariant
+import net.theevilreaper.dartpoet.DartFile
+import net.theevilreaper.dartpoet.DartModifier
+import net.theevilreaper.dartpoet.clazz.ClassSpec
+import net.theevilreaper.dartpoet.constructor.ConstructorSpec
+import net.theevilreaper.dartpoet.enum.EnumEntrySpec
+import net.theevilreaper.dartpoet.enum.parameter.EnumParameterSpec
+import net.theevilreaper.dartpoet.parameter.ParameterSpec
+import net.theevilreaper.dartpoet.property.PropertySpec
+import net.theevilreaper.stelaris.cli.generator.BaseGenerator
+import net.theevilreaper.stelaris.cli.util.EMPTY_STRING
+import net.theevilreaper.stelaris.cli.util.StringHelper
+import java.nio.file.Path
+
+/**
+ * Generates the [PaintingVariant] enum for dart.
+ * @version 1.0.0
+ * @since 1.0.0
+ * @author theEvilReaper
+ */
+class PaintingVariantGenerator : BaseGenerator(
+    className = "PaintingVariant",
+    packageName = "painting",
+) {
+
+    override fun generate(outputPath: Path) {
+        val folder = checkPackageFolder(outputPath, packageName)
+        val registry = PaintingVariant.createDefaultRegistry()
+        val enumEntries = mutableListOf<EnumEntrySpec>()
+
+        val sortedEntries = registry.values().sortedBy { registry.getKey(it)?.name() ?: EMPTY_STRING }
+
+        for (variant in sortedEntries) {
+            val key = registry.getKey(variant)?.name() ?: continue
+            val nameWithoutPrefix = key.replace("minecraft:", EMPTY_STRING)
+            val variableName = StringHelper.toLowerCamelCase(nameWithoutPrefix)
+            val displayName = StringHelper.mapDisplayName(nameWithoutPrefix)
+
+            enumEntries.add(
+                EnumEntrySpec.builder(variableName)
+                    .parameter(EnumParameterSpec.positional("%C", displayName))
+                    .parameter(EnumParameterSpec.positional("%C", key))
+                    .parameter(EnumParameterSpec.positional("%L", variant.width()))
+                    .parameter(EnumParameterSpec.positional("%L", variant.height()))
+                    .parameter(EnumParameterSpec.positional("%C", variant.assetId().asString()))
+                    .build()
+            )
+        }
+
+        val enumClass = ClassSpec.enumClass(className)
+            .enumProperties(*enumEntries.toTypedArray())
+            .properties(
+                PropertySpec.builder("displayName", String::class).modifier(DartModifier.FINAL).build(),
+                PropertySpec.builder("key", String::class).modifier(DartModifier.FINAL).build(),
+                PropertySpec.builder("width", Int::class).modifier(DartModifier.FINAL).build(),
+                PropertySpec.builder("height", Int::class).modifier(DartModifier.FINAL).build(),
+                PropertySpec.builder("assetId", String::class).modifier(DartModifier.FINAL).build()
+            )
+            .constructor(
+                ConstructorSpec.builder(className)
+                    .modifier(DartModifier.CONST)
+                    .parameters(
+                        ParameterSpec.positional("displayName").build(),
+                        ParameterSpec.positional("key").build(),
+                        ParameterSpec.positional("width").build(),
+                        ParameterSpec.positional("height").build(),
+                        ParameterSpec.positional("assetId").build()
+                    )
+                    .build()
+            )
+            .build()
+
+        val file = DartFile.builder("painting_variant")
+            .doc("The file is generated. Don't change anything here")
+            .type(enumClass)
+            .build()
+        file.write(folder)
+    }
+
+    override fun getName() = "PaintingVariantGenerator"
+}

--- a/src/test/kotlin/net/theevilreaper/stelaris/cli/generator/GeneratorRegistryTest.kt
+++ b/src/test/kotlin/net/theevilreaper/stelaris/cli/generator/GeneratorRegistryTest.kt
@@ -9,6 +9,6 @@ class GeneratorRegistryTest {
     fun testGetGenerators() {
         val generatorRegistry = GeneratorRegistry()
         val generators = generatorRegistry.getGenerators()
-        assertEquals(17, generators.size)
+        assertEquals(24, generators.size)
     }
 }

--- a/src/test/kotlin/net/theevilreaper/stelaris/cli/generator/dart/banner/BannerPatternGeneratorTest.kt
+++ b/src/test/kotlin/net/theevilreaper/stelaris/cli/generator/dart/banner/BannerPatternGeneratorTest.kt
@@ -1,0 +1,35 @@
+package net.theevilreaper.stelaris.cli.generator.dart.banner
+
+import net.theevilreaper.stelaris.cli.generator.GenerationTestBase
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class BannerPatternGeneratorTest : GenerationTestBase() {
+
+    @Test
+    fun `test banner pattern generation`() {
+        val generator = BannerPatternGenerator()
+        assertEquals("BannerPatternGenerator", generator.getName())
+
+        generator.generate(generationPath)
+
+        val folder = generationPath.resolve("banner").toFile()
+        assertTrue(folder.exists(), "Expected generated folder to exist")
+        val generatedFiles = folder.listFiles()
+        assertNotNull(generatedFiles)
+        assertEquals(1, generatedFiles!!.size, "Expected exactly one file to be generated")
+
+        val generatedFile = generatedFiles.first()
+        assertEquals("banner_pattern.dart", generatedFile.name)
+
+        val content = generatedFile.readText()
+        assertTrue(content.contains("enum BannerPattern"), "Generated file should declare BannerPattern enum")
+        assertTrue(content.contains("final String displayName;"))
+        assertTrue(content.contains("final String key;"))
+        assertTrue(content.contains("final String assetId;"))
+        assertTrue(content.contains("final String translationKey;"))
+        assertTrue(content.contains("flower('Flower', 'minecraft:flower', 'minecraft:flower', 'block.minecraft.banner.flower')"))
+    }
+}

--- a/src/test/kotlin/net/theevilreaper/stelaris/cli/generator/dart/damage/DamageTypeGeneratorTest.kt
+++ b/src/test/kotlin/net/theevilreaper/stelaris/cli/generator/dart/damage/DamageTypeGeneratorTest.kt
@@ -1,0 +1,35 @@
+package net.theevilreaper.stelaris.cli.generator.dart.damage
+
+import net.theevilreaper.stelaris.cli.generator.GenerationTestBase
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class DamageTypeGeneratorTest : GenerationTestBase() {
+
+    @Test
+    fun `test damage type generation`() {
+        val generator = DamageTypeGenerator()
+        assertEquals("DamageTypeGenerator", generator.getName())
+
+        generator.generate(generationPath)
+
+        val folder = generationPath.resolve("damage").toFile()
+        assertTrue(folder.exists(), "Expected generated folder to exist")
+        val generatedFiles = folder.listFiles()
+        assertNotNull(generatedFiles)
+        assertEquals(1, generatedFiles!!.size, "Expected exactly one file to be generated")
+
+        val generatedFile = generatedFiles.first()
+        assertEquals("damage_type.dart", generatedFile.name)
+
+        val content = generatedFile.readText()
+        assertTrue(content.contains("enum DamageType"), "Generated file should declare DamageType enum")
+        assertTrue(content.contains("final String displayName;"))
+        assertTrue(content.contains("final String key;"))
+        assertTrue(content.contains("final String messageId;"))
+        assertTrue(content.contains("final double exhaustion;"))
+        assertTrue(content.contains("inFire('In Fire', 'minecraft:in_fire', 'inFire', 0.1)"))
+    }
+}

--- a/src/test/kotlin/net/theevilreaper/stelaris/cli/generator/dart/item/InstrumentGeneratorTest.kt
+++ b/src/test/kotlin/net/theevilreaper/stelaris/cli/generator/dart/item/InstrumentGeneratorTest.kt
@@ -1,0 +1,35 @@
+package net.theevilreaper.stelaris.cli.generator.dart.item
+
+import net.theevilreaper.stelaris.cli.generator.GenerationTestBase
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class InstrumentGeneratorTest : GenerationTestBase() {
+
+    @Test
+    fun `test instrument generation`() {
+        val generator = InstrumentGenerator()
+        assertEquals("InstrumentGenerator", generator.getName())
+
+        generator.generate(generationPath)
+
+        val folder = generationPath.resolve("item").toFile()
+        assertTrue(folder.exists(), "Expected generated folder to exist")
+        val generatedFiles = folder.listFiles()
+        assertNotNull(generatedFiles)
+        assertEquals(1, generatedFiles!!.size, "Expected exactly one file to be generated")
+
+        val generatedFile = generatedFiles.first()
+        assertEquals("instrument.dart", generatedFile.name)
+
+        val content = generatedFile.readText()
+        assertTrue(content.contains("enum Instrument"), "Generated file should declare Instrument enum")
+        assertTrue(content.contains("final String displayName;"))
+        assertTrue(content.contains("final String key;"))
+        assertTrue(content.contains("final double range;"))
+        assertTrue(content.contains("final double useDuration;"))
+        assertTrue(content.contains("ponderGoatHorn('Ponder Goat Horn', 'minecraft:ponder_goat_horn', 256.0, 7.0)"))
+    }
+}

--- a/src/test/kotlin/net/theevilreaper/stelaris/cli/generator/dart/item/JukeboxSongGeneratorTest.kt
+++ b/src/test/kotlin/net/theevilreaper/stelaris/cli/generator/dart/item/JukeboxSongGeneratorTest.kt
@@ -1,0 +1,35 @@
+package net.theevilreaper.stelaris.cli.generator.dart.item
+
+import net.theevilreaper.stelaris.cli.generator.GenerationTestBase
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class JukeboxSongGeneratorTest : GenerationTestBase() {
+
+    @Test
+    fun `test jukebox song generation`() {
+        val generator = JukeboxSongGenerator()
+        assertEquals("JukeboxSongGenerator", generator.getName())
+
+        generator.generate(generationPath)
+
+        val folder = generationPath.resolve("item").toFile()
+        assertTrue(folder.exists(), "Expected generated folder to exist")
+        val generatedFiles = folder.listFiles()
+        assertNotNull(generatedFiles)
+        assertEquals(1, generatedFiles!!.size, "Expected exactly one file to be generated")
+
+        val generatedFile = generatedFiles.first()
+        assertEquals("jukebox_song.dart", generatedFile.name)
+
+        val content = generatedFile.readText()
+        assertTrue(content.contains("enum JukeboxSong"), "Generated file should declare JukeboxSong enum")
+        assertTrue(content.contains("final String displayName;"))
+        assertTrue(content.contains("final String key;"))
+        assertTrue(content.contains("final double lengthInSeconds;"))
+        assertTrue(content.contains("final int comparatorOutput;"))
+        assertTrue(content.contains("pigstep('Pigstep', 'minecraft:pigstep', 149.0, 13)"))
+    }
+}

--- a/src/test/kotlin/net/theevilreaper/stelaris/cli/generator/dart/item/TrimMaterialGeneratorTest.kt
+++ b/src/test/kotlin/net/theevilreaper/stelaris/cli/generator/dart/item/TrimMaterialGeneratorTest.kt
@@ -1,0 +1,34 @@
+package net.theevilreaper.stelaris.cli.generator.dart.item
+
+import net.theevilreaper.stelaris.cli.generator.GenerationTestBase
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class TrimMaterialGeneratorTest : GenerationTestBase() {
+
+    @Test
+    fun `test trim material generation`() {
+        val generator = TrimMaterialGenerator()
+        assertEquals("TrimMaterialGenerator", generator.getName())
+
+        generator.generate(generationPath)
+
+        val folder = generationPath.resolve("item").toFile()
+        assertTrue(folder.exists(), "Expected generated folder to exist")
+        val generatedFiles = folder.listFiles()
+        assertNotNull(generatedFiles)
+        assertEquals(1, generatedFiles!!.size, "Expected exactly one file to be generated")
+
+        val generatedFile = generatedFiles.first()
+        assertEquals("trim_material.dart", generatedFile.name)
+
+        val content = generatedFile.readText()
+        assertTrue(content.contains("enum TrimMaterial"), "Generated file should declare TrimMaterial enum")
+        assertTrue(content.contains("final String displayName;"))
+        assertTrue(content.contains("final String key;"))
+        assertTrue(content.contains("final String assetId;"))
+        assertTrue(content.contains("diamond('Diamond', 'minecraft:diamond', 'diamond')"))
+    }
+}

--- a/src/test/kotlin/net/theevilreaper/stelaris/cli/generator/dart/item/TrimPatternGeneratorTest.kt
+++ b/src/test/kotlin/net/theevilreaper/stelaris/cli/generator/dart/item/TrimPatternGeneratorTest.kt
@@ -1,0 +1,35 @@
+package net.theevilreaper.stelaris.cli.generator.dart.item
+
+import net.theevilreaper.stelaris.cli.generator.GenerationTestBase
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class TrimPatternGeneratorTest : GenerationTestBase() {
+
+    @Test
+    fun `test trim pattern generation`() {
+        val generator = TrimPatternGenerator()
+        assertEquals("TrimPatternGenerator", generator.getName())
+
+        generator.generate(generationPath)
+
+        val folder = generationPath.resolve("item").toFile()
+        assertTrue(folder.exists(), "Expected generated folder to exist")
+        val generatedFiles = folder.listFiles()
+        assertNotNull(generatedFiles)
+        assertEquals(1, generatedFiles!!.size, "Expected exactly one file to be generated")
+
+        val generatedFile = generatedFiles.first()
+        assertEquals("trim_pattern.dart", generatedFile.name)
+
+        val content = generatedFile.readText()
+        assertTrue(content.contains("enum TrimPattern"), "Generated file should declare TrimPattern enum")
+        assertTrue(content.contains("final String displayName;"))
+        assertTrue(content.contains("final String key;"))
+        assertTrue(content.contains("final String assetId;"))
+        assertTrue(content.contains("final bool decal;"))
+        assertTrue(content.contains("sentry('Sentry', 'minecraft:sentry', 'minecraft:sentry', false)"))
+    }
+}

--- a/src/test/kotlin/net/theevilreaper/stelaris/cli/generator/dart/painting/PaintingVariantGeneratorTest.kt
+++ b/src/test/kotlin/net/theevilreaper/stelaris/cli/generator/dart/painting/PaintingVariantGeneratorTest.kt
@@ -1,0 +1,36 @@
+package net.theevilreaper.stelaris.cli.generator.dart.painting
+
+import net.theevilreaper.stelaris.cli.generator.GenerationTestBase
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class PaintingVariantGeneratorTest : GenerationTestBase() {
+
+    @Test
+    fun `test painting variant generation`() {
+        val generator = PaintingVariantGenerator()
+        assertEquals("PaintingVariantGenerator", generator.getName())
+
+        generator.generate(generationPath)
+
+        val folder = generationPath.resolve("painting").toFile()
+        assertTrue(folder.exists(), "Expected generated folder to exist")
+        val generatedFiles = folder.listFiles()
+        assertNotNull(generatedFiles)
+        assertEquals(1, generatedFiles!!.size, "Expected exactly one file to be generated")
+
+        val generatedFile = generatedFiles.first()
+        assertEquals("painting_variant.dart", generatedFile.name)
+
+        val content = generatedFile.readText()
+        assertTrue(content.contains("enum PaintingVariant"), "Generated file should declare PaintingVariant enum")
+        assertTrue(content.contains("final String displayName;"))
+        assertTrue(content.contains("final String key;"))
+        assertTrue(content.contains("final int width;"))
+        assertTrue(content.contains("final int height;"))
+        assertTrue(content.contains("final String assetId;"))
+        assertTrue(content.contains("kebab('Kebab', 'minecraft:kebab', 1, 1, 'minecraft:kebab')"))
+    }
+}


### PR DESCRIPTION
## Proposed changes

Minecraft has internal registries which handles specific values. This pull request add some basic registry generation.

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the CONTRIBUTING.md
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)