### PR TITLE
feat(generator): register generators through guice instead of a hardcoded set

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,10 +1,12 @@
 import org.gradle.api.artifacts.result.ResolvedDependencyResult
+import java.util.zip.ZipFile
 
 plugins {
     jacoco
     application
     alias(libs.plugins.kotlin)
     alias(libs.plugins.shadow)
+    alias(libs.plugins.ksp)
 }
 
 group = "net.theevilreaper"
@@ -20,6 +22,9 @@ dependencies {
     implementation(libs.minestom)
     implementation(libs.guava)
     implementation(libs.jgit)
+    implementation(libs.google.guice)
+    implementation(libs.autoservice.annotations)
+    ksp(libs.autoservice.ksp)
 
     testImplementation(libs.cyano)
     testImplementation(libs.junit.jupiter)
@@ -55,6 +60,26 @@ tasks.register("resolveMinestomVersion") {
     }
 }
 
+// Generators are discovered through META-INF/services. Without mergeServiceFiles() in the
+// shadowJar task that file does not survive into the fat jar and the CLI starts with an empty
+// registry - a failure that only shows up when running the released artifact.
+val verifyShadowJarServices = tasks.register("verifyShadowJarServices") {
+    description = "Verifies that the shadow jar carries the generator service file."
+    dependsOn(tasks.shadowJar)
+    val jarFile = tasks.shadowJar.flatMap { it.archiveFile }
+    val serviceEntry = "META-INF/services/net.theevilreaper.stelaris.cli.generator.Generator"
+    doLast {
+        ZipFile(jarFile.get().asFile).use { jar ->
+            val entry = jar.getEntry(serviceEntry)
+                ?: error("$serviceEntry is missing from the shadow jar. Is mergeServiceFiles() still set?")
+            val generators = jar.getInputStream(entry).bufferedReader().readLines()
+                .filter { it.isNotBlank() }
+            check(generators.isNotEmpty()) { "$serviceEntry is empty in the shadow jar" }
+            logger.lifecycle("Shadow jar registers ${generators.size} generators")
+        }
+    }
+}
+
 tasks {
     compileJava {
         options.encoding = "UTF-8"
@@ -71,6 +96,9 @@ tasks {
     }
 
     shadowJar {
+        // The generator registry is discovered through META-INF/services, so the
+        // service files of every dependency have to survive the merge into the fat jar.
+        mergeServiceFiles()
         archiveBaseName.set("stelaris-cli")
         archiveClassifier.set("")
         archiveVersion.set("")
@@ -80,7 +108,7 @@ tasks {
     }
 
     build {
-        dependsOn(shadowJar)
+        dependsOn(shadowJar, verifyShadowJarServices)
     }
 
     test {

--- a/docs/superpowers/specs/2026-08-28-guice-generator-registrierung-design.md
+++ b/docs/superpowers/specs/2026-08-28-guice-generator-registrierung-design.md
@@ -1,0 +1,238 @@
+# Guice-basierte Generator-Registrierung
+
+Datum: 2026-08-28
+Status: Entwurf zur Umsetzung freigegeben
+
+## Problem
+
+`GeneratorRegistry` hält alle 28 Generatoren in einer hartkodierten `setOf(...)`
+(`GeneratorRegistry.kt:36`). Jeder neue Generator muss an zwei Stellen eingetragen
+werden — Klasse anlegen und Registry ergänzen —, und ein vergessener Eintrag fällt
+nirgends auf. Die Instanzen entstehen außerdem alle beim Konstruieren der Registry,
+auch die, die der aktuelle Lauf gar nicht verwendet.
+
+Ziel: Ein Generator wird allein dadurch registriert, dass er als Klasse existiert und
+annotiert ist — Auto-Discovery wie `@ComponentScan` in Spring Boot, umgesetzt mit
+Guice.
+
+## Entscheidung
+
+Auto-Discovery über den JDK-`ServiceLoader`, dessen Registrierungsdatei zur Compile-Zeit
+von Googles `@AutoService`-Processor erzeugt wird. Guice bindet die gefundenen Klassen
+über einen `Multibinder<GeneratorDescriptor>`.
+
+Verworfene Alternativen:
+
+- **Expliziter Multibinder**: verschiebt die Liste nur von der Registry ins Modul.
+- **Classpath-Scan zur Laufzeit** (Guava `ClassPath`): erreicht dasselbe ohne
+  Build-Änderung, stützt sich aber auf eine `@Beta`-API, kostet 30–100 ms Startzeit und
+  muss gegen das Shadow-Jar abgesichert werden.
+- **Eigener KSP-Processor**: einziger Ansatz, der eine vergessene Annotation zur
+  Compile-Zeit meldet, verlangt dafür aber einen Multi-Module-Umbau und einen selbst
+  gepflegten Processor.
+
+`@AutoService` liefert den Nutzen des KSP-Ansatzes (Registrierung entsteht beim
+Kompilieren, kein Laufzeit-Scan) ohne dessen Infrastrukturkosten.
+
+## Architektur
+
+### Komponenten
+
+**`@CodeGenerator`** (vorhanden, wird angepasst) — trägt `name` und `experimental` und
+ist alleinige Quelle dieser Metadaten. Die Retention wechselt von `BINARY` auf
+`RUNTIME`, da `GeneratorModule` die Werte zur Laufzeit ausliest.
+
+**`@AutoService(Generator::class)`** — veranlasst den Processor, die Klasse in
+`META-INF/services/net.theevilreaper.stelaris.cli.generator.Generator` einzutragen.
+
+**`GeneratorDescriptor`** (vorhanden, unverändert) — `name`, `experimental` und ein
+`Provider<out Generator>`; `create()` erzeugt die Instanz erst bei Bedarf.
+
+**`GeneratorModule`** (vorhanden, wird gefüllt) — liest die Service-Datei und bindet je
+einen Descriptor in einen `Multibinder<GeneratorDescriptor>`:
+
+```kotlin
+class GeneratorModule : AbstractModule() {
+
+    override fun configure() {
+        val multibinder = Multibinder.newSetBinder(binder(), GeneratorDescriptor::class.java)
+        ServiceLoader.load(Generator::class.java, javaClass.classLoader)
+            .stream()
+            .forEach { service ->
+                val type = service.type()
+                val metadata = requireNotNull(type.getAnnotation(CodeGenerator::class.java)) {
+                    "${type.name} is registered as a Generator service but lacks @CodeGenerator"
+                }
+                multibinder.addBinding().toInstance(
+                    GeneratorDescriptor(metadata.name, metadata.experimental, getProvider(type))
+                )
+            }
+    }
+}
+```
+
+`ServiceLoader` dient ausschließlich der Entdeckung: `service.type()` liefert die Klasse,
+ohne sie zu instanziieren. Gebaut wird sie von Guice über `getProvider(type)`. Dadurch
+bleibt die Lazy-Semantik erhalten, und Generatoren können später `@Inject`-Abhängigkeiten
+erhalten, was ein direkter `ServiceLoader`-Aufruf ausschlösse.
+
+**`GeneratorRegistry`** — bekommt das `Set<GeneratorDescriptor>` injiziert, prüft es beim
+Konstruieren und filtert auf Descriptor-Ebene:
+
+```kotlin
+@Singleton
+class GeneratorRegistry @Inject constructor(
+    private val descriptors: Set<GeneratorDescriptor>,
+) {
+    init {
+        check(descriptors.isNotEmpty()) {
+            "No generators were discovered. When running from the shadow jar this usually " +
+                "means mergeServiceFiles() is missing from the shadowJar task."
+        }
+        val duplicates = descriptors.groupBy { it.name }.filterValues { it.size > 1 }.keys
+        check(duplicates.isEmpty()) { "Duplicate generator names: $duplicates" }
+    }
+
+    fun getDescriptors(): Set<GeneratorDescriptor> = descriptors
+
+    fun createGenerators(predicate: (GeneratorDescriptor) -> Boolean = { true }): Set<Generator> =
+        descriptors.filter(predicate).map { it.create() }.toSet()
+}
+```
+
+### Datenfluss
+
+1. Kompilieren: Der Processor sammelt alle `@AutoService(Generator::class)`-Klassen und
+   schreibt die Service-Datei.
+2. Start: `Guice.createInjector(GeneratorModule())` liest die Datei, legt pro Eintrag
+   einen Descriptor an und bindet ihn.
+3. Registry: prüft auf Leere und Namensdubletten — schlägt fehl, bevor irgendein
+   Generator läuft.
+4. `StelarisCLI`: filtert Descriptoren nach dem `-experimental`-Schalter und ruft
+   `create()` nur für die verbleibenden auf.
+
+Ein Nicht-Experimental-Lauf konstruiert experimentelle Generatoren damit nie — heute
+werden alle 28 gebaut, unabhängig davon, ob sie verwendet werden.
+
+## Änderungen im Einzelnen
+
+### Generator-Vertrag
+
+`Generator` behält `generate(outputPath)` und `cleanUp()`. `getName()` und
+`isExperimental()` entfallen; die Metadaten liefert die Annotation über den Descriptor.
+In `BaseGenerator` entfallen das `experimental`-Feld und der Import von
+`org.jetbrains.annotations.ApiStatus`.
+
+Beobachtung zur Ausgangslage: `getName()` wird in `src/main` an keiner Stelle aufgerufen —
+nur 20 Tests prüfen damit den eigenen Klassennamen. Produktiv genutzt wird allein
+`isExperimental()` in `StelarisCLI.kt:35`. Ebenso ruft kein Produktionscode `cleanUp()`
+auf; das bleibt hier unangetastet, weil es nichts mit der DI-Umstellung zu tun hat.
+
+Zweite Beobachtung: Kein Generator trägt derzeit `@ApiStatus.Experimental`. Der
+`-experimental`-Schalter der CLI hat damit aktuell keine Wirkung. Das neue
+`experimental`-Feld der Annotation erhält diese Fähigkeit für die Zukunft, ändert aber am
+heutigen Verhalten nichts — alle 28 Generatoren werden mit `experimental = false`
+annotiert.
+
+### Alle 28 Generator-Klassen
+
+Je Klasse: `@AutoService(Generator::class)` und `@CodeGenerator(name = "<Klassenname>")`
+ergänzen, `override fun getName()` entfernen. Als `name` wird der bisherige
+`getName()`-Rückgabewert übernommen (der einfache Klassenname), damit sich an Log- und
+Fehlerausgaben nichts ändert.
+
+### Einstiegspunkt
+
+`StelarisCLI.kt:21` ersetzt `GeneratorRegistry()` durch den Injector; die Filterung
+wandert auf den Descriptor:
+
+```kotlin
+val registry = Guice.createInjector(GeneratorModule()).getInstance(GeneratorRegistry::class.java)
+val generators = registry.createGenerators { parsedArgs.experimental || !it.experimental }
+```
+
+Die bisherige Prüfung `if (generators.isEmpty())` mit der Meldung
+`"The cli needs generators to run"` entfällt: Eine leere Menge ist kein Bedienfehler,
+sondern ein Defekt, und wird schon beim Konstruieren der Registry gemeldet.
+
+### Build
+
+```kotlin
+plugins { alias(libs.plugins.ksp) }
+
+dependencies {
+    implementation(libs.autoservice.annotations)  // com.google.auto.service:auto-service-annotations:1.1.1
+    ksp(libs.autoservice.ksp)                     // dev.zacsweers.autoservice:auto-service-ksp:1.2.0
+}
+
+tasks.shadowJar { mergeServiceFiles() }
+```
+
+Version Catalog und Plugin-Deklaration kommen wie im Projekt üblich inline nach
+`settings.gradle.kts`. `mergeServiceFiles()` fehlt heute und ist zwingend: ohne diesen
+Aufruf enthält das Fat-Jar keine nutzbare Service-Datei und die CLI startet mit leerer
+Registry.
+
+Die Änderungen am Build werden vorab gegen die OLF-Gradle-Konvention
+(`minestom-knowledge:gradle`) abgeglichen.
+
+## Fehlerbehandlung
+
+| Fehlerfall | Erkennung |
+|---|---|
+| Annotierte Klasse implementiert `Generator` nicht | Compile-Fehler durch den AutoService-Processor |
+| Service-Klasse ohne `@CodeGenerator` | `CreationException` beim Injector-Bau |
+| Doppelter Generator-Name | `IllegalStateException` im Registry-Konstruktor |
+| Keine Generatoren gefunden | `IllegalStateException` mit Hinweis auf `mergeServiceFiles()` |
+| `@AutoService` vergessen | nicht automatisch — siehe Vollständigkeitstest |
+
+Der letzte Fall ist die bekannte Schwäche jedes Discovery-Ansatzes ohne eigenen Processor
+und wird durch einen Test abgefangen statt durch den Compiler.
+
+## Tests
+
+**`GeneratorModuleTest`** (neu): baut einen echten Injector und prüft, dass Descriptoren
+gefunden werden, alle Namen eindeutig und nicht leer sind und jeder Descriptor sich
+instanziieren lässt.
+
+**Vollständigkeitstest** (neu): sucht im Testklassenpfad mit Guavas `ClassPath` alle
+`Generator`-Implementierungen unterhalb von `…generator.dart` und vergleicht sie mit den
+gebundenen Descriptoren. Fehlt an einer Klasse die `@AutoService`-Annotation, schlägt
+dieser Test fehl. Guava wird damit nur im Test verwendet, nicht im Produktionspfad.
+
+**`verifyShadowJarServices`** (neuer Gradle-Task, an `build` gehängt): prüft, dass
+`META-INF/services/net.theevilreaper.stelaris.cli.generator.Generator` im Shadow-Jar liegt
+und so viele Einträge hat wie es Generatoren gibt. Sichert `mergeServiceFiles()` dauerhaft
+ab.
+
+**Anzupassen:** `GeneratorRegistryTest` (`assertEquals(28, …)` entfällt ersatzlos — die
+Zahl kann nicht mehr driften), die 20 Generator-Tests mit
+`assertEquals("XGenerator", generator.getName())` (Assert entfällt) und der
+`Generator`-Fake in `LocalProjectExporterTest.kt:20` (Overrides für `getName()` und
+`isExperimental()` entfernen).
+
+## Risiken
+
+**KSP mit Kotlin 2.4.10.** Seit Version 2.3.0 ist KSP von der Kotlin-Version entkoppelt
+(aktuell 2.3.11); die Kombination ist aber noch nicht praktisch verifiziert. Erster
+Umsetzungsschritt ist daher ein minimaler Build-Durchlauf mit KSP. Schlägt er fehl, ist
+der Fallback `kapt("com.google.auto.service:auto-service:1.1.1")` mit Googles
+Original-Processor — dieselbe Annotation, dasselbe Ergebnis, ohne KSP.
+
+**Diff-Größe.** Angefasst werden 28 Generatoren, 22 Testdateien, Interface, Basisklasse,
+Modul, Registry, Einstiegspunkt und Build. Die Schritte 3 und 4 der Reihenfolge unten sind
+rein mechanisch und sollten getrennt committet werden.
+
+## Umsetzungsreihenfolge
+
+1. KSP-Plugin und AutoService-Abhängigkeiten ins Build, `mergeServiceFiles()` ergänzen,
+   Kompatibilität mit einem Wegwerf-Generator verifizieren.
+2. `@CodeGenerator` auf `RUNTIME` umstellen, `GeneratorModule` implementieren,
+   `GeneratorRegistry` auf Descriptoren umbauen.
+3. Alle 28 Generatoren annotieren, `getName()`-Overrides entfernen.
+4. `Generator` und `BaseGenerator` verschlanken.
+5. `StelarisCLI` auf den Injector umstellen.
+6. Tests: neue Modul- und Vollständigkeitstests, bestehende Tests anpassen,
+   `verifyShadowJarServices` ergänzen.
+7. `./gradlew build` inklusive Shadow-Jar plus ein realer CLI-Lauf gegen ein
+   Ausgabeverzeichnis als Gegenprobe.

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -30,6 +30,7 @@ dependencyResolutionManagement {
             version("guava", "33.7.1-jre")
             version("jgit", "7.7.1.202607240634-r")
             version("shadow", "9.6.1")
+            version("ksp", "2.3.11")
 
             library("mycelium.bom", "net.onelitefeather", "mycelium-bom").versionRef("bom")
             library("minestom", "net.minestom", "minestom").withoutVersion()
@@ -42,8 +43,13 @@ dependencyResolutionManagement {
             library("junit.jupiter.engine", "org.junit.jupiter", "junit-jupiter-engine").versionRef("junit")
             library("junit.platform.launcher", "org.junit.platform", "junit-platform-launcher").version("6.1.3")
 
+            library("google.guice", "com.google.inject", "guice").version("7.0.0")
+            library("autoservice.annotations", "com.google.auto.service", "auto-service-annotations").version("1.1.1")
+            library("autoservice.ksp", "dev.zacsweers.autoservice", "auto-service-ksp").version("1.2.0")
+
             plugin("kotlin", "org.jetbrains.kotlin.jvm").versionRef("kotlin")
             plugin("shadow", "com.gradleup.shadow").versionRef("shadow")
+            plugin("ksp", "com.google.devtools.ksp").versionRef("ksp")
         }
     }
 }

--- a/src/main/kotlin/net/theevilreaper/stelaris/cli/StelarisCLI.kt
+++ b/src/main/kotlin/net/theevilreaper/stelaris/cli/StelarisCLI.kt
@@ -1,5 +1,6 @@
 package net.theevilreaper.stelaris.cli
 
+import com.google.inject.Guice
 import net.minestom.server.MinecraftServer
 import net.theevilreaper.stelaris.cli.arguments.CommandArgument
 import net.theevilreaper.stelaris.cli.arguments.ParsedArgs
@@ -7,6 +8,7 @@ import net.theevilreaper.stelaris.cli.exporter.ExportStrategy
 import net.theevilreaper.stelaris.cli.exporter.GitProjectExporter
 import net.theevilreaper.stelaris.cli.exporter.LocalProjectExporter
 import net.theevilreaper.stelaris.cli.generator.Generator
+import net.theevilreaper.stelaris.cli.generator.GeneratorModule
 import net.theevilreaper.stelaris.cli.generator.GeneratorRegistry
 import net.theevilreaper.stelaris.cli.util.*
 import java.nio.file.Files
@@ -18,7 +20,6 @@ fun main(args: Array<String>) {
         return
     }
 
-    val generatorRegistry = GeneratorRegistry()
     val parsedArgs = parseArguments(args)
 
     if (parsedArgs.showHelp) {
@@ -31,14 +32,10 @@ fun main(args: Array<String>) {
         return
     }
 
-    val generators: Set<Generator> = when (parsedArgs.experimental) {
-        false -> generatorRegistry.getGenerators { !it.isExperimental() }
-        true -> generatorRegistry.getGenerators()
-    }
-
-    if (generators.isEmpty()) {
-        println("The cli needs generators to run")
-        return
+    val registry = Guice.createInjector(GeneratorModule())
+        .getInstance(GeneratorRegistry::class.java)
+    val generators: Set<Generator> = registry.createGenerators {
+        parsedArgs.experimental || !it.experimental
     }
 
     // Use the user-specified path if provided; otherwise, use the default for Git

--- a/src/main/kotlin/net/theevilreaper/stelaris/cli/generator/BaseGenerator.kt
+++ b/src/main/kotlin/net/theevilreaper/stelaris/cli/generator/BaseGenerator.kt
@@ -1,7 +1,6 @@
 package net.theevilreaper.stelaris.cli.generator
 
 import net.theevilreaper.dartpoet.DartFile
-import org.jetbrains.annotations.ApiStatus
 import java.nio.file.Files
 
 import java.nio.file.Path
@@ -15,10 +14,6 @@ abstract class BaseGenerator(
     val className: String,
     val packageName: String,
 ) : Generator {
-
-    private val experimental: Boolean by lazy {
-        this.javaClass.isAnnotationPresent(ApiStatus.Experimental::class.java)
-    }
 
     /**
      * Clears the internal file cache.
@@ -46,15 +41,4 @@ abstract class BaseGenerator(
      */
     abstract override fun generate(outputPath: Path)
 
-    /**
-     * Returns the name from the generator.
-     * @return the given name as string
-     */
-    abstract override fun getName(): String
-
-    /**
-     * Returns whether the generator is experimental or not.
-     * @return true if the generator is experimental, false otherwise
-     */
-    override fun isExperimental(): Boolean = experimental
 }

--- a/src/main/kotlin/net/theevilreaper/stelaris/cli/generator/CodeGenerator.kt
+++ b/src/main/kotlin/net/theevilreaper/stelaris/cli/generator/CodeGenerator.kt
@@ -1,3 +1,22 @@
 package net.theevilreaper.stelaris.cli.generator
 
-annotation class CodeGenerator()
+/**
+ * Carries the metadata of a [Generator] implementation.
+ *
+ * The annotation is the single source of truth for the name and the experimental flag of a
+ * generator. It is read by the [GeneratorModule] while the injector is built, which allows the
+ * [GeneratorRegistry] to filter generators without instantiating them.
+ *
+ * A generator additionally needs `@AutoService(Generator::class)` to be discovered at all. The
+ * annotation processor writes it into the service file which the module reads at startup.
+ * @version 1.0.0
+ * @since 1.0.0
+ * @property name the identifying name of the generator
+ * @property experimental whether the generator may have incomplete functionality
+ */
+@Target(AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class CodeGenerator(
+    val name: String,
+    val experimental: Boolean = false,
+)

--- a/src/main/kotlin/net/theevilreaper/stelaris/cli/generator/CodeGenerator.kt
+++ b/src/main/kotlin/net/theevilreaper/stelaris/cli/generator/CodeGenerator.kt
@@ -1,0 +1,3 @@
+package net.theevilreaper.stelaris.cli.generator
+
+annotation class CodeGenerator()

--- a/src/main/kotlin/net/theevilreaper/stelaris/cli/generator/Generator.kt
+++ b/src/main/kotlin/net/theevilreaper/stelaris/cli/generator/Generator.kt
@@ -5,6 +5,10 @@ import java.nio.file.Path
 /**
  * The interface defines the basic structure for code generators in the Stelaris CLI.
  * All generator implementations must follow this contract.
+ *
+ * An implementation is registered by annotating it with `@AutoService(Generator::class)` and
+ * [CodeGenerator]. The name and the experimental flag live on the annotation and are exposed
+ * through the [GeneratorDescriptor], not through the generator itself.
  * @author Joltras
  * @version 1.0.0
  * @since 1.0.0
@@ -18,22 +22,8 @@ interface Generator {
     fun generate(outputPath: Path)
 
     /**
-     * Returns the name from the generator.
-     * This is used to identify the generator in logs and other output.
-     * @return the generator's identifying name
-     */
-    fun getName(): String
-
-    /**
      * Cleans up any resources or state data used by the generator.
      * This should be called after the generation is complete.
      */
     fun cleanUp()
-
-    /**
-     * Indicates if the generator is considered experimental.
-     * Experimental generators may have incomplete functionality or be subject to change.
-     * @return true if the generator is experimental, false otherwise
-     */
-    fun isExperimental(): Boolean
 }

--- a/src/main/kotlin/net/theevilreaper/stelaris/cli/generator/GeneratorDescriptor.kt
+++ b/src/main/kotlin/net/theevilreaper/stelaris/cli/generator/GeneratorDescriptor.kt
@@ -1,0 +1,4 @@
+package net.theevilreaper.stelaris.cli.generator
+
+class GeneratorDescriptor {
+}

--- a/src/main/kotlin/net/theevilreaper/stelaris/cli/generator/GeneratorDescriptor.kt
+++ b/src/main/kotlin/net/theevilreaper/stelaris/cli/generator/GeneratorDescriptor.kt
@@ -1,4 +1,29 @@
 package net.theevilreaper.stelaris.cli.generator
 
-class GeneratorDescriptor {
+import jakarta.inject.Provider
+
+/**
+ * Describes a [Generator] without creating it.
+ *
+ * The descriptor exposes the metadata from [CodeGenerator] so that generators can be selected
+ * before any of them is constructed. The instance is only created when [create] is called.
+ * @version 1.0.0
+ * @since 1.0.0
+ * @property name the identifying name of the generator
+ * @property experimental whether the generator may have incomplete functionality
+ * @property provider the provider which creates the generator instance
+ */
+class GeneratorDescriptor(
+    val name: String,
+    val experimental: Boolean,
+    private val provider: Provider<out Generator>,
+) {
+
+    /**
+     * Creates the generator described by this descriptor.
+     * @return the created [Generator]
+     */
+    fun create(): Generator = provider.get()
+
+    override fun toString() = name
 }

--- a/src/main/kotlin/net/theevilreaper/stelaris/cli/generator/GeneratorModule.kt
+++ b/src/main/kotlin/net/theevilreaper/stelaris/cli/generator/GeneratorModule.kt
@@ -1,0 +1,4 @@
+package net.theevilreaper.stelaris.cli.generator
+
+class GeneratorModule {
+}

--- a/src/main/kotlin/net/theevilreaper/stelaris/cli/generator/GeneratorModule.kt
+++ b/src/main/kotlin/net/theevilreaper/stelaris/cli/generator/GeneratorModule.kt
@@ -1,4 +1,34 @@
 package net.theevilreaper.stelaris.cli.generator
 
-class GeneratorModule {
+import com.google.inject.AbstractModule
+import com.google.inject.multibindings.Multibinder
+import java.util.ServiceLoader
+
+/**
+ * Binds every discovered [Generator] as a [GeneratorDescriptor].
+ *
+ * Discovery happens through the service file which the `@AutoService` processor writes at compile
+ * time. The [ServiceLoader] is only used to find the classes: [ServiceLoader.Provider.type] returns
+ * the class without instantiating it, and the instance itself is created by Guice. That keeps the
+ * creation lazy and allows generators to receive injected dependencies later on.
+ * @version 1.0.0
+ * @since 1.0.0
+ */
+class GeneratorModule : AbstractModule() {
+
+    override fun configure() {
+        val multibinder = Multibinder.newSetBinder(binder(), GeneratorDescriptor::class.java)
+
+        ServiceLoader.load(Generator::class.java, javaClass.classLoader)
+            .stream()
+            .forEach { service ->
+                val type = service.type()
+                val metadata = requireNotNull(type.getAnnotation(CodeGenerator::class.java)) {
+                    "${type.name} is registered as a Generator service but is not annotated with @CodeGenerator"
+                }
+                multibinder.addBinding().toInstance(
+                    GeneratorDescriptor(metadata.name, metadata.experimental, getProvider(type)),
+                )
+            }
+    }
 }

--- a/src/main/kotlin/net/theevilreaper/stelaris/cli/generator/GeneratorRegistry.kt
+++ b/src/main/kotlin/net/theevilreaper/stelaris/cli/generator/GeneratorRegistry.kt
@@ -1,78 +1,45 @@
 package net.theevilreaper.stelaris.cli.generator
 
-import net.theevilreaper.stelaris.cli.generator.dart.*
-import net.theevilreaper.stelaris.cli.generator.dart.banner.BannerPatternGenerator
-import net.theevilreaper.stelaris.cli.generator.dart.bossbar.BossBarColorGenerator
-import net.theevilreaper.stelaris.cli.generator.dart.bossbar.BossBarFlagGenerator
-import net.theevilreaper.stelaris.cli.generator.dart.bossbar.BossBarOverlayGenerator
-import net.theevilreaper.stelaris.cli.generator.dart.color.DyeColorGenerator
-import net.theevilreaper.stelaris.cli.generator.dart.damage.DamageTypeGenerator
-import net.theevilreaper.stelaris.cli.generator.dart.enchantment.EnchantmentGenerator
-import net.theevilreaper.stelaris.cli.generator.dart.enchantment.EnchantmentGroupGenerator
-import net.theevilreaper.stelaris.cli.generator.dart.entity.variant.EntityVariantGenerator
-import net.theevilreaper.stelaris.cli.generator.dart.item.*
-import net.theevilreaper.stelaris.cli.generator.dart.painting.PaintingVariantGenerator
-import net.theevilreaper.stelaris.cli.generator.dart.sound.SoundEventGenerator
-import net.theevilreaper.stelaris.cli.generator.dart.sound.SoundSourceGenerator
-import net.theevilreaper.stelaris.cli.generator.dart.sound.SoundTypeGenerator
-import net.theevilreaper.stelaris.cli.generator.dart.villager.VillagerTypeGenerator
-import net.theevilreaper.stelaris.cli.generator.dart.world.BiomeGenerator
-import net.theevilreaper.stelaris.cli.generator.dart.world.DifficultyGenerator
-import net.theevilreaper.stelaris.cli.generator.dart.world.DimensionTypeGenerator
-import net.theevilreaper.stelaris.cli.generator.dart.world.GameModeGenerator
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
 
 /**
- * The [GeneratorRegistry] holds all available generators which can be used to generate dart files.
+ * The [GeneratorRegistry] holds a descriptor for every available generator.
+ *
+ * The descriptors are contributed by the [GeneratorModule] and carry the metadata of each
+ * generator. Selecting generators therefore does not require creating them: only the descriptors
+ * which pass the given filter are turned into instances.
  * @version 1.0.0
  * @since 1.0.0
- * @property generators the set of all available generators
+ * @property descriptors the descriptors of all available generators
  * @author theEvilReaper
  */
-class GeneratorRegistry {
+@Singleton
+class GeneratorRegistry @Inject constructor(
+    private val descriptors: Set<@JvmSuppressWildcards GeneratorDescriptor>,
+) {
 
-    private val generators: Set<Generator> = setOf(
-        BannerPatternGenerator(),
-        BiomeGenerator(),
-        BossBarColorGenerator(),
-        BossBarFlagGenerator(),
-        BossBarOverlayGenerator(),
-        DamageTypeGenerator(),
-        DifficultyGenerator(),
-        DimensionTypeGenerator(),
-        DyeColorGenerator(),
-        EnchantmentGenerator(),
-        EnchantmentGroupGenerator(),
-        EntityTypeGenerator(),
-        EntityVariantGenerator(),
-        FireworkShapeGenerator(),
-        FrameTypeGenerator(),
-        GameModeGenerator(),
-        InstrumentGenerator(),
-        ItemRarityGenerator(),
-        JukeboxSongGenerator(),
-        MaterialGenerator(),
-        MapPostProcessingGenerator(),
-        PaintingVariantGenerator(),
-        SoundSourceGenerator(),
-        SoundEventGenerator(),
-        SoundTypeGenerator(),
-        TrimMaterialGenerator(),
-        TrimPatternGenerator(),
-        VillagerTypeGenerator()
-    )
+    init {
+        check(descriptors.isNotEmpty()) {
+            "No generators were discovered. When running from the shadow jar this usually means " +
+                "mergeServiceFiles() is missing from the shadowJar task"
+        }
+        val duplicates = descriptors.groupBy { it.name }.filterValues { it.size > 1 }.keys
+        check(duplicates.isEmpty()) { "Duplicate generator names: ${duplicates.joinToString()}" }
+    }
 
     /**
-     * Returns all available generators from the registry
-     * @return a set of all available generators
+     * Returns the descriptors of all available generators.
+     * @return a set of all available descriptors
      */
-    fun getGenerators(): Set<Generator> = generators
+    fun getDescriptors(): Set<GeneratorDescriptor> = descriptors
 
     /**
-     * Returns all available generators that match the given predicate
-     * @param predicate the predicate to filter the generators
-     * @return a set of all available generators which match the predicate
+     * Creates the generators whose descriptor matches the given predicate.
+     * @param predicate the predicate to filter the descriptors
+     * @return a set with an instance of every matching generator
      */
-    fun getGenerators(predicate: (Generator) -> Boolean): Set<Generator> {
-        return generators.filter { predicate(it) }.toSet()
+    fun createGenerators(predicate: (GeneratorDescriptor) -> Boolean = { true }): Set<Generator> {
+        return descriptors.filter(predicate).map { it.create() }.toSet()
     }
 }

--- a/src/main/kotlin/net/theevilreaper/stelaris/cli/generator/dart/EntityTypeGenerator.kt
+++ b/src/main/kotlin/net/theevilreaper/stelaris/cli/generator/dart/EntityTypeGenerator.kt
@@ -1,14 +1,19 @@
 package net.theevilreaper.stelaris.cli.generator.dart
 
+import com.google.auto.service.AutoService
 import net.minestom.server.entity.EntityType
 import net.theevilreaper.dartpoet.DartFile
 import net.theevilreaper.dartpoet.clazz.ClassSpec
 import net.theevilreaper.stelaris.cli.generator.BaseGenerator
+import net.theevilreaper.stelaris.cli.generator.CodeGenerator
+import net.theevilreaper.stelaris.cli.generator.Generator
 import net.theevilreaper.stelaris.cli.generator.dart.entity.EntitySubGenerator
 import net.theevilreaper.stelaris.cli.generator.dart.entity.EntitySubType
 import net.theevilreaper.stelaris.cli.util.StringHelper
 import java.nio.file.Path
 
+@AutoService(Generator::class)
+@CodeGenerator(name = "EntityTypeGenerator")
 class EntityTypeGenerator : BaseGenerator(
     className = "Entities",
     packageName = "entities",
@@ -57,6 +62,4 @@ class EntityTypeGenerator : BaseGenerator(
         val enumClass = EntitySubGenerator.generateEntityEnum(className, filteredEntities)
         return enumClass.build()
     }
-
-    override fun getName() = "EntityTypeGenerator"
 }

--- a/src/main/kotlin/net/theevilreaper/stelaris/cli/generator/dart/FrameTypeGenerator.kt
+++ b/src/main/kotlin/net/theevilreaper/stelaris/cli/generator/dart/FrameTypeGenerator.kt
@@ -1,5 +1,6 @@
 package net.theevilreaper.stelaris.cli.generator.dart
 
+import com.google.auto.service.AutoService
 import net.minestom.server.advancements.FrameType
 import net.theevilreaper.dartpoet.DartFile
 import net.theevilreaper.dartpoet.DartModifier
@@ -10,9 +11,13 @@ import net.theevilreaper.dartpoet.enum.parameter.EnumParameterSpec
 import net.theevilreaper.dartpoet.parameter.ParameterSpec
 import net.theevilreaper.dartpoet.property.PropertySpec
 import net.theevilreaper.stelaris.cli.generator.BaseGenerator
+import net.theevilreaper.stelaris.cli.generator.CodeGenerator
+import net.theevilreaper.stelaris.cli.generator.Generator
 import net.theevilreaper.stelaris.cli.util.StringHelper
 import java.nio.file.Path
 
+@AutoService(Generator::class)
+@CodeGenerator(name = "FrameTypeGenerator")
 class FrameTypeGenerator : BaseGenerator(
     className = "FrameType",
     packageName = "frame_type",
@@ -44,6 +49,4 @@ class FrameTypeGenerator : BaseGenerator(
             .build()
         file.write(outputPath)
     }
-
-    override fun getName() = "FrameTypeGenerator"
 }

--- a/src/main/kotlin/net/theevilreaper/stelaris/cli/generator/dart/MaterialGenerator.kt
+++ b/src/main/kotlin/net/theevilreaper/stelaris/cli/generator/dart/MaterialGenerator.kt
@@ -1,10 +1,13 @@
 package net.theevilreaper.stelaris.cli.generator.dart
 
+import com.google.auto.service.AutoService
 import net.minestom.server.component.DataComponents
 import net.minestom.server.item.Material
 import net.theevilreaper.dartpoet.DartFile
 import net.theevilreaper.dartpoet.clazz.ClassSpec
 import net.theevilreaper.stelaris.cli.generator.BaseGenerator
+import net.theevilreaper.stelaris.cli.generator.CodeGenerator
+import net.theevilreaper.stelaris.cli.generator.Generator
 import net.theevilreaper.stelaris.cli.generator.dart.material.MaterialSubGenerator
 import net.theevilreaper.stelaris.cli.generator.dart.material.MaterialSubType
 import net.theevilreaper.stelaris.cli.util.StringHelper
@@ -14,6 +17,8 @@ import java.nio.file.Path
  *
  * @author theEvilReaper
  */
+@AutoService(Generator::class)
+@CodeGenerator(name = "MaterialGenerator")
 class MaterialGenerator : BaseGenerator(
     className = "Materials",
     packageName = "materials",
@@ -86,10 +91,4 @@ class MaterialGenerator : BaseGenerator(
     ): List<Material> {
         return materials.filter { filter(it) }
     }
-
-    /**
-     * Returns the name from [MaterialGenerator] which is used as identifier.
-     * @return the given name
-     */
-    override fun getName() = "MaterialGenerator"
 }

--- a/src/main/kotlin/net/theevilreaper/stelaris/cli/generator/dart/banner/BannerPatternGenerator.kt
+++ b/src/main/kotlin/net/theevilreaper/stelaris/cli/generator/dart/banner/BannerPatternGenerator.kt
@@ -1,5 +1,6 @@
 package net.theevilreaper.stelaris.cli.generator.dart.banner
 
+import com.google.auto.service.AutoService
 import net.minestom.server.instance.block.banner.BannerPattern
 import net.theevilreaper.dartpoet.DartFile
 import net.theevilreaper.dartpoet.DartModifier
@@ -10,6 +11,8 @@ import net.theevilreaper.dartpoet.enum.parameter.EnumParameterSpec
 import net.theevilreaper.dartpoet.parameter.ParameterSpec
 import net.theevilreaper.dartpoet.property.PropertySpec
 import net.theevilreaper.stelaris.cli.generator.BaseGenerator
+import net.theevilreaper.stelaris.cli.generator.CodeGenerator
+import net.theevilreaper.stelaris.cli.generator.Generator
 import net.theevilreaper.stelaris.cli.util.EMPTY_STRING
 import net.theevilreaper.stelaris.cli.util.StringHelper
 import java.nio.file.Path
@@ -20,6 +23,8 @@ import java.nio.file.Path
  * @since 1.0.0
  * @author theEvilReaper
  */
+@AutoService(Generator::class)
+@CodeGenerator(name = "BannerPatternGenerator")
 class BannerPatternGenerator : BaseGenerator(
     className = "BannerPattern",
     packageName = "banner",
@@ -75,6 +80,4 @@ class BannerPatternGenerator : BaseGenerator(
             .build()
         file.write(folder)
     }
-
-    override fun getName() = "BannerPatternGenerator"
 }

--- a/src/main/kotlin/net/theevilreaper/stelaris/cli/generator/dart/bossbar/BossBarColorGenerator.kt
+++ b/src/main/kotlin/net/theevilreaper/stelaris/cli/generator/dart/bossbar/BossBarColorGenerator.kt
@@ -1,5 +1,6 @@
 package net.theevilreaper.stelaris.cli.generator.dart.bossbar
 
+import com.google.auto.service.AutoService
 import net.kyori.adventure.bossbar.BossBar
 import net.theevilreaper.dartpoet.DartFile
 import net.theevilreaper.dartpoet.DartModifier
@@ -8,11 +9,15 @@ import net.theevilreaper.dartpoet.constructor.ConstructorSpec
 import net.theevilreaper.dartpoet.enum.EnumEntrySpec
 import net.theevilreaper.dartpoet.enum.parameter.EnumParameterSpec
 import net.theevilreaper.stelaris.cli.generator.BaseGenerator
+import net.theevilreaper.stelaris.cli.generator.CodeGenerator
+import net.theevilreaper.stelaris.cli.generator.Generator
 import net.theevilreaper.stelaris.cli.generator.dart.util.DEFAULT_PARAMETERS
 import net.theevilreaper.stelaris.cli.generator.dart.util.DEFAULT_PROPERTIES
 import net.theevilreaper.stelaris.cli.util.StringHelper
 import java.nio.file.Path
 
+@AutoService(Generator::class)
+@CodeGenerator(name = "BossBarColorGenerator")
 class BossBarColorGenerator : BaseGenerator(
     className = "BossBarColor",
     packageName = "bossbar",
@@ -54,6 +59,4 @@ class BossBarColorGenerator : BaseGenerator(
             .build()
         file.write(folder)
     }
-
-    override fun getName(): String = "BossBarColorGenerator"
 }

--- a/src/main/kotlin/net/theevilreaper/stelaris/cli/generator/dart/bossbar/BossBarFlagGenerator.kt
+++ b/src/main/kotlin/net/theevilreaper/stelaris/cli/generator/dart/bossbar/BossBarFlagGenerator.kt
@@ -1,5 +1,6 @@
 package net.theevilreaper.stelaris.cli.generator.dart.bossbar
 
+import com.google.auto.service.AutoService
 import net.kyori.adventure.bossbar.BossBar
 import net.theevilreaper.dartpoet.DartFile
 import net.theevilreaper.dartpoet.DartModifier
@@ -8,11 +9,15 @@ import net.theevilreaper.dartpoet.constructor.ConstructorSpec
 import net.theevilreaper.dartpoet.enum.EnumEntrySpec
 import net.theevilreaper.dartpoet.enum.parameter.EnumParameterSpec
 import net.theevilreaper.stelaris.cli.generator.BaseGenerator
+import net.theevilreaper.stelaris.cli.generator.CodeGenerator
+import net.theevilreaper.stelaris.cli.generator.Generator
 import net.theevilreaper.stelaris.cli.generator.dart.util.DEFAULT_PARAMETERS
 import net.theevilreaper.stelaris.cli.generator.dart.util.DEFAULT_PROPERTIES
 import net.theevilreaper.stelaris.cli.util.StringHelper
 import java.nio.file.Path
 
+@AutoService(Generator::class)
+@CodeGenerator(name = "BossBarFlagGenerator")
 class BossBarFlagGenerator : BaseGenerator(
     "BossBarFlag",
     "bossbar",
@@ -54,6 +59,4 @@ class BossBarFlagGenerator : BaseGenerator(
             .build()
         file.write(folder)
     }
-
-    override fun getName(): String = "BossBarFlagGenerator"
 }

--- a/src/main/kotlin/net/theevilreaper/stelaris/cli/generator/dart/bossbar/BossBarOverlayGenerator.kt
+++ b/src/main/kotlin/net/theevilreaper/stelaris/cli/generator/dart/bossbar/BossBarOverlayGenerator.kt
@@ -1,5 +1,6 @@
 package net.theevilreaper.stelaris.cli.generator.dart.bossbar
 
+import com.google.auto.service.AutoService
 import net.kyori.adventure.bossbar.BossBar
 import net.theevilreaper.dartpoet.DartFile
 import net.theevilreaper.dartpoet.DartModifier
@@ -8,11 +9,15 @@ import net.theevilreaper.dartpoet.constructor.ConstructorSpec
 import net.theevilreaper.dartpoet.enum.EnumEntrySpec
 import net.theevilreaper.dartpoet.enum.parameter.EnumParameterSpec
 import net.theevilreaper.stelaris.cli.generator.BaseGenerator
+import net.theevilreaper.stelaris.cli.generator.CodeGenerator
+import net.theevilreaper.stelaris.cli.generator.Generator
 import net.theevilreaper.stelaris.cli.generator.dart.util.DEFAULT_PARAMETERS
 import net.theevilreaper.stelaris.cli.generator.dart.util.DEFAULT_PROPERTIES
 import net.theevilreaper.stelaris.cli.util.StringHelper
 import java.nio.file.Path
 
+@AutoService(Generator::class)
+@CodeGenerator(name = "BossBarOverlayGenerator")
 class BossBarOverlayGenerator : BaseGenerator(
     className = "BossBarOverlay",
     packageName = "bossbar"
@@ -48,6 +53,4 @@ class BossBarOverlayGenerator : BaseGenerator(
             .build()
         file.write(folder)
     }
-
-    override fun getName(): String = "BossBarOverlayGenerator"
 }

--- a/src/main/kotlin/net/theevilreaper/stelaris/cli/generator/dart/color/DyeColorGenerator.kt
+++ b/src/main/kotlin/net/theevilreaper/stelaris/cli/generator/dart/color/DyeColorGenerator.kt
@@ -1,5 +1,6 @@
 package net.theevilreaper.stelaris.cli.generator.dart.color
 
+import com.google.auto.service.AutoService
 import net.minestom.server.color.DyeColor
 import net.theevilreaper.dartpoet.DartFile
 import net.theevilreaper.dartpoet.DartModifier
@@ -13,9 +14,13 @@ import net.theevilreaper.dartpoet.parameter.ParameterSpec
 import net.theevilreaper.dartpoet.property.PropertySpec
 import net.theevilreaper.dartpoet.type.ClassName
 import net.theevilreaper.stelaris.cli.generator.BaseGenerator
+import net.theevilreaper.stelaris.cli.generator.CodeGenerator
+import net.theevilreaper.stelaris.cli.generator.Generator
 import net.theevilreaper.stelaris.cli.util.StringHelper
 import java.nio.file.Path
 
+@AutoService(Generator::class)
+@CodeGenerator(name = "DyeColorGenerator")
 class DyeColorGenerator : BaseGenerator(
     className = "DyeColor",
     packageName = "color",
@@ -86,6 +91,4 @@ class DyeColorGenerator : BaseGenerator(
     private fun formatColor(rgb: Int): String {
         return "Color.fromRGB(0x%06x)".format(rgb)
     }
-
-    override fun getName() = "DyeColorGenerator"
 }

--- a/src/main/kotlin/net/theevilreaper/stelaris/cli/generator/dart/damage/DamageTypeGenerator.kt
+++ b/src/main/kotlin/net/theevilreaper/stelaris/cli/generator/dart/damage/DamageTypeGenerator.kt
@@ -1,5 +1,6 @@
 package net.theevilreaper.stelaris.cli.generator.dart.damage
 
+import com.google.auto.service.AutoService
 import net.minestom.server.entity.damage.DamageType
 import net.theevilreaper.dartpoet.DartFile
 import net.theevilreaper.dartpoet.DartModifier
@@ -10,6 +11,8 @@ import net.theevilreaper.dartpoet.enum.parameter.EnumParameterSpec
 import net.theevilreaper.dartpoet.parameter.ParameterSpec
 import net.theevilreaper.dartpoet.property.PropertySpec
 import net.theevilreaper.stelaris.cli.generator.BaseGenerator
+import net.theevilreaper.stelaris.cli.generator.CodeGenerator
+import net.theevilreaper.stelaris.cli.generator.Generator
 import net.theevilreaper.stelaris.cli.util.EMPTY_STRING
 import net.theevilreaper.stelaris.cli.util.StringHelper
 import java.nio.file.Path
@@ -20,6 +23,8 @@ import java.nio.file.Path
  * @since 1.0.0
  * @author theEvilReaper
  */
+@AutoService(Generator::class)
+@CodeGenerator(name = "DamageTypeGenerator")
 class DamageTypeGenerator : BaseGenerator(
     className = "DamageType",
     packageName = "damage",
@@ -77,6 +82,4 @@ class DamageTypeGenerator : BaseGenerator(
             .build()
         file.write(folder)
     }
-
-    override fun getName() = "DamageTypeGenerator"
 }

--- a/src/main/kotlin/net/theevilreaper/stelaris/cli/generator/dart/enchantment/EnchantmentGenerator.kt
+++ b/src/main/kotlin/net/theevilreaper/stelaris/cli/generator/dart/enchantment/EnchantmentGenerator.kt
@@ -1,5 +1,6 @@
 package net.theevilreaper.stelaris.cli.generator.dart.enchantment
 
+import com.google.auto.service.AutoService
 import net.kyori.adventure.text.TranslatableComponent
 import net.minestom.server.MinecraftServer
 import net.minestom.server.item.enchant.Enchantment
@@ -13,6 +14,8 @@ import net.theevilreaper.dartpoet.enum.EnumEntrySpec
 import net.theevilreaper.dartpoet.enum.parameter.EnumParameterSpec
 import net.theevilreaper.dartpoet.type.ClassName
 import net.theevilreaper.stelaris.cli.generator.BaseGenerator
+import net.theevilreaper.stelaris.cli.generator.CodeGenerator
+import net.theevilreaper.stelaris.cli.generator.Generator
 import net.theevilreaper.stelaris.cli.generator.dart.util.CLASS_PROPERTIES
 import net.theevilreaper.stelaris.cli.generator.dart.util.CONSTRUCTOR_PARAMETERS
 import net.theevilreaper.stelaris.cli.util.EMPTY_STRING
@@ -27,6 +30,8 @@ import java.nio.file.Path
  * @since 1.0.0
  * @author theEvilReaper
  */
+@AutoService(Generator::class)
+@CodeGenerator(name = "EnchantmentGenerator")
 class EnchantmentGenerator : BaseGenerator(
     className = "Enchantment",
     packageName = "enchantment",
@@ -100,10 +105,4 @@ class EnchantmentGenerator : BaseGenerator(
             .parameter(EnumParameterSpec.positional("%L", enchantment.maxLevel()))
             .build()
     }
-
-    /**
-     * Returns the name of the generator.
-     * @return the name
-     */
-    override fun getName() = "EnchantmentGenerator"
 }

--- a/src/main/kotlin/net/theevilreaper/stelaris/cli/generator/dart/enchantment/EnchantmentGroupGenerator.kt
+++ b/src/main/kotlin/net/theevilreaper/stelaris/cli/generator/dart/enchantment/EnchantmentGroupGenerator.kt
@@ -1,5 +1,6 @@
 package net.theevilreaper.stelaris.cli.generator.dart.enchantment
 
+import com.google.auto.service.AutoService
 import net.theevilreaper.dartpoet.DartFile
 import net.theevilreaper.dartpoet.DartModifier
 import net.theevilreaper.dartpoet.clazz.ClassSpec
@@ -9,9 +10,13 @@ import net.theevilreaper.dartpoet.enum.parameter.EnumParameterSpec
 import net.theevilreaper.dartpoet.parameter.ParameterSpec
 import net.theevilreaper.dartpoet.property.PropertySpec
 import net.theevilreaper.stelaris.cli.generator.BaseGenerator
+import net.theevilreaper.stelaris.cli.generator.CodeGenerator
+import net.theevilreaper.stelaris.cli.generator.Generator
 import net.theevilreaper.stelaris.cli.util.StringHelper
 import java.nio.file.Path
 
+@AutoService(Generator::class)
+@CodeGenerator(name = "EnchantmentGroupGenerator")
 class EnchantmentGroupGenerator : BaseGenerator(
     packageName = "enchantment",
     className = "EnchantmentGroup"
@@ -52,6 +57,4 @@ class EnchantmentGroupGenerator : BaseGenerator(
 
         classFile.write(enchantmentFolder)
     }
-
-    override fun getName(): String = "EnchantmentGroupGenerator"
 }

--- a/src/main/kotlin/net/theevilreaper/stelaris/cli/generator/dart/entity/variant/EntityVariantGenerator.kt
+++ b/src/main/kotlin/net/theevilreaper/stelaris/cli/generator/dart/entity/variant/EntityVariantGenerator.kt
@@ -1,5 +1,6 @@
 package net.theevilreaper.stelaris.cli.generator.dart.entity.variant
 
+import com.google.auto.service.AutoService
 import net.minestom.server.entity.metadata.animal.FoxMeta
 import net.minestom.server.entity.metadata.animal.MooshroomMeta
 import net.minestom.server.entity.metadata.animal.RabbitMeta
@@ -15,9 +16,13 @@ import net.theevilreaper.dartpoet.enum.parameter.EnumParameterSpec
 import net.theevilreaper.dartpoet.parameter.ParameterSpec
 import net.theevilreaper.dartpoet.property.PropertySpec
 import net.theevilreaper.stelaris.cli.generator.BaseGenerator
+import net.theevilreaper.stelaris.cli.generator.CodeGenerator
+import net.theevilreaper.stelaris.cli.generator.Generator
 import net.theevilreaper.stelaris.cli.util.StringHelper
 import java.nio.file.Path
 
+@AutoService(Generator::class)
+@CodeGenerator(name = "EntityVariantGenerator")
 class EntityVariantGenerator : BaseGenerator(
     className = "EntityVariant",
     packageName = "entity/variant",
@@ -164,6 +169,4 @@ class EntityVariantGenerator : BaseGenerator(
             .type(enumClass)
             .build()
     }
-
-    override fun getName() = "EntityVariantGenerator"
 }

--- a/src/main/kotlin/net/theevilreaper/stelaris/cli/generator/dart/item/FireworkShapeGenerator.kt
+++ b/src/main/kotlin/net/theevilreaper/stelaris/cli/generator/dart/item/FireworkShapeGenerator.kt
@@ -1,5 +1,6 @@
 package net.theevilreaper.stelaris.cli.generator.dart.item
 
+import com.google.auto.service.AutoService
 import net.minestom.server.item.component.FireworkExplosion
 import net.theevilreaper.dartpoet.DartFile
 import net.theevilreaper.dartpoet.DartModifier
@@ -10,9 +11,13 @@ import net.theevilreaper.dartpoet.enum.parameter.EnumParameterSpec
 import net.theevilreaper.dartpoet.parameter.ParameterSpec
 import net.theevilreaper.dartpoet.property.PropertySpec
 import net.theevilreaper.stelaris.cli.generator.BaseGenerator
+import net.theevilreaper.stelaris.cli.generator.CodeGenerator
+import net.theevilreaper.stelaris.cli.generator.Generator
 import net.theevilreaper.stelaris.cli.util.StringHelper
 import java.nio.file.Path
 
+@AutoService(Generator::class)
+@CodeGenerator(name = "FireworkShapeGenerator")
 class FireworkShapeGenerator : BaseGenerator(
     className = "FireworkShape",
     packageName = "item",
@@ -61,6 +66,4 @@ class FireworkShapeGenerator : BaseGenerator(
             .build()
         enumFile.write(folder)
     }
-
-    override fun getName() = "FireworkShapeGenerator"
 }

--- a/src/main/kotlin/net/theevilreaper/stelaris/cli/generator/dart/item/InstrumentGenerator.kt
+++ b/src/main/kotlin/net/theevilreaper/stelaris/cli/generator/dart/item/InstrumentGenerator.kt
@@ -1,5 +1,6 @@
 package net.theevilreaper.stelaris.cli.generator.dart.item
 
+import com.google.auto.service.AutoService
 import net.minestom.server.item.instrument.Instrument
 import net.theevilreaper.dartpoet.DartFile
 import net.theevilreaper.dartpoet.DartModifier
@@ -10,6 +11,8 @@ import net.theevilreaper.dartpoet.enum.parameter.EnumParameterSpec
 import net.theevilreaper.dartpoet.parameter.ParameterSpec
 import net.theevilreaper.dartpoet.property.PropertySpec
 import net.theevilreaper.stelaris.cli.generator.BaseGenerator
+import net.theevilreaper.stelaris.cli.generator.CodeGenerator
+import net.theevilreaper.stelaris.cli.generator.Generator
 import net.theevilreaper.stelaris.cli.util.EMPTY_STRING
 import net.theevilreaper.stelaris.cli.util.StringHelper
 import java.nio.file.Path
@@ -20,6 +23,8 @@ import java.nio.file.Path
  * @since 1.0.0
  * @author theEvilReaper
  */
+@AutoService(Generator::class)
+@CodeGenerator(name = "InstrumentGenerator")
 class InstrumentGenerator : BaseGenerator(
     className = "Instrument",
     packageName = "item",
@@ -75,6 +80,4 @@ class InstrumentGenerator : BaseGenerator(
             .build()
         file.write(folder)
     }
-
-    override fun getName() = "InstrumentGenerator"
 }

--- a/src/main/kotlin/net/theevilreaper/stelaris/cli/generator/dart/item/ItemRarityGenerator.kt
+++ b/src/main/kotlin/net/theevilreaper/stelaris/cli/generator/dart/item/ItemRarityGenerator.kt
@@ -1,5 +1,6 @@
 package net.theevilreaper.stelaris.cli.generator.dart.item
 
+import com.google.auto.service.AutoService
 import net.minestom.server.item.component.ItemRarity
 import net.theevilreaper.dartpoet.DartFile
 import net.theevilreaper.dartpoet.DartModifier
@@ -12,9 +13,13 @@ import net.theevilreaper.dartpoet.enum.parameter.EnumParameterSpec
 import net.theevilreaper.dartpoet.parameter.ParameterSpec
 import net.theevilreaper.dartpoet.property.PropertySpec
 import net.theevilreaper.stelaris.cli.generator.BaseGenerator
+import net.theevilreaper.stelaris.cli.generator.CodeGenerator
+import net.theevilreaper.stelaris.cli.generator.Generator
 import net.theevilreaper.stelaris.cli.util.StringHelper
 import java.nio.file.Path
 
+@AutoService(Generator::class)
+@CodeGenerator(name = "ItemRarityGenerator")
 class ItemRarityGenerator : BaseGenerator(
     className = "ItemRarity",
     packageName = "item",
@@ -55,6 +60,4 @@ class ItemRarityGenerator : BaseGenerator(
         enumFile.write(folder)
 
     }
-
-    override fun getName() = "ItemRarityGenerator"
 }

--- a/src/main/kotlin/net/theevilreaper/stelaris/cli/generator/dart/item/JukeboxSongGenerator.kt
+++ b/src/main/kotlin/net/theevilreaper/stelaris/cli/generator/dart/item/JukeboxSongGenerator.kt
@@ -1,5 +1,6 @@
 package net.theevilreaper.stelaris.cli.generator.dart.item
 
+import com.google.auto.service.AutoService
 import net.minestom.server.instance.block.jukebox.JukeboxSong
 import net.theevilreaper.dartpoet.DartFile
 import net.theevilreaper.dartpoet.DartModifier
@@ -10,6 +11,8 @@ import net.theevilreaper.dartpoet.enum.parameter.EnumParameterSpec
 import net.theevilreaper.dartpoet.parameter.ParameterSpec
 import net.theevilreaper.dartpoet.property.PropertySpec
 import net.theevilreaper.stelaris.cli.generator.BaseGenerator
+import net.theevilreaper.stelaris.cli.generator.CodeGenerator
+import net.theevilreaper.stelaris.cli.generator.Generator
 import net.theevilreaper.stelaris.cli.util.EMPTY_STRING
 import net.theevilreaper.stelaris.cli.util.StringHelper
 import java.nio.file.Path
@@ -20,6 +23,8 @@ import java.nio.file.Path
  * @since 1.0.0
  * @author theEvilReaper
  */
+@AutoService(Generator::class)
+@CodeGenerator(name = "JukeboxSongGenerator")
 class JukeboxSongGenerator : BaseGenerator(
     className = "JukeboxSong",
     packageName = "item",
@@ -75,6 +80,4 @@ class JukeboxSongGenerator : BaseGenerator(
             .build()
         file.write(folder)
     }
-
-    override fun getName() = "JukeboxSongGenerator"
 }

--- a/src/main/kotlin/net/theevilreaper/stelaris/cli/generator/dart/item/MapPostProcessingGenerator.kt
+++ b/src/main/kotlin/net/theevilreaper/stelaris/cli/generator/dart/item/MapPostProcessingGenerator.kt
@@ -1,5 +1,6 @@
 package net.theevilreaper.stelaris.cli.generator.dart.item
 
+import com.google.auto.service.AutoService
 import net.minestom.server.item.component.MapPostProcessing
 import net.theevilreaper.dartpoet.DartFile
 import net.theevilreaper.dartpoet.DartModifier
@@ -10,9 +11,13 @@ import net.theevilreaper.dartpoet.enum.parameter.EnumParameterSpec
 import net.theevilreaper.dartpoet.parameter.ParameterSpec
 import net.theevilreaper.dartpoet.property.PropertySpec
 import net.theevilreaper.stelaris.cli.generator.BaseGenerator
+import net.theevilreaper.stelaris.cli.generator.CodeGenerator
+import net.theevilreaper.stelaris.cli.generator.Generator
 import net.theevilreaper.stelaris.cli.util.StringHelper
 import java.nio.file.Path
 
+@AutoService(Generator::class)
+@CodeGenerator(name = "MapPostProcessingGenerator")
 class MapPostProcessingGenerator : BaseGenerator(
     className = "MapPostProcessing",
     packageName = "item",
@@ -52,6 +57,4 @@ class MapPostProcessingGenerator : BaseGenerator(
             .build()
         enumFile.write(folder)
     }
-
-    override fun getName() = "MapPostProcessingGenerator"
 }

--- a/src/main/kotlin/net/theevilreaper/stelaris/cli/generator/dart/item/TrimMaterialGenerator.kt
+++ b/src/main/kotlin/net/theevilreaper/stelaris/cli/generator/dart/item/TrimMaterialGenerator.kt
@@ -1,5 +1,6 @@
 package net.theevilreaper.stelaris.cli.generator.dart.item
 
+import com.google.auto.service.AutoService
 import net.minestom.server.item.armor.TrimMaterial
 import net.theevilreaper.dartpoet.DartFile
 import net.theevilreaper.dartpoet.DartModifier
@@ -10,6 +11,8 @@ import net.theevilreaper.dartpoet.enum.parameter.EnumParameterSpec
 import net.theevilreaper.dartpoet.parameter.ParameterSpec
 import net.theevilreaper.dartpoet.property.PropertySpec
 import net.theevilreaper.stelaris.cli.generator.BaseGenerator
+import net.theevilreaper.stelaris.cli.generator.CodeGenerator
+import net.theevilreaper.stelaris.cli.generator.Generator
 import net.theevilreaper.stelaris.cli.util.EMPTY_STRING
 import net.theevilreaper.stelaris.cli.util.StringHelper
 import java.nio.file.Path
@@ -20,6 +23,8 @@ import java.nio.file.Path
  * @since 1.0.0
  * @author theEvilReaper
  */
+@AutoService(Generator::class)
+@CodeGenerator(name = "TrimMaterialGenerator")
 class TrimMaterialGenerator : BaseGenerator(
     className = "TrimMaterial",
     packageName = "item",
@@ -72,6 +77,4 @@ class TrimMaterialGenerator : BaseGenerator(
             .build()
         file.write(folder)
     }
-
-    override fun getName() = "TrimMaterialGenerator"
 }

--- a/src/main/kotlin/net/theevilreaper/stelaris/cli/generator/dart/item/TrimPatternGenerator.kt
+++ b/src/main/kotlin/net/theevilreaper/stelaris/cli/generator/dart/item/TrimPatternGenerator.kt
@@ -1,5 +1,6 @@
 package net.theevilreaper.stelaris.cli.generator.dart.item
 
+import com.google.auto.service.AutoService
 import net.minestom.server.item.armor.TrimPattern
 import net.theevilreaper.dartpoet.DartFile
 import net.theevilreaper.dartpoet.DartModifier
@@ -10,6 +11,8 @@ import net.theevilreaper.dartpoet.enum.parameter.EnumParameterSpec
 import net.theevilreaper.dartpoet.parameter.ParameterSpec
 import net.theevilreaper.dartpoet.property.PropertySpec
 import net.theevilreaper.stelaris.cli.generator.BaseGenerator
+import net.theevilreaper.stelaris.cli.generator.CodeGenerator
+import net.theevilreaper.stelaris.cli.generator.Generator
 import net.theevilreaper.stelaris.cli.util.EMPTY_STRING
 import net.theevilreaper.stelaris.cli.util.StringHelper
 import java.nio.file.Path
@@ -20,6 +23,8 @@ import java.nio.file.Path
  * @since 1.0.0
  * @author theEvilReaper
  */
+@AutoService(Generator::class)
+@CodeGenerator(name = "TrimPatternGenerator")
 class TrimPatternGenerator : BaseGenerator(
     className = "TrimPattern",
     packageName = "item",
@@ -75,6 +80,4 @@ class TrimPatternGenerator : BaseGenerator(
             .build()
         file.write(folder)
     }
-
-    override fun getName() = "TrimPatternGenerator"
 }

--- a/src/main/kotlin/net/theevilreaper/stelaris/cli/generator/dart/painting/PaintingVariantGenerator.kt
+++ b/src/main/kotlin/net/theevilreaper/stelaris/cli/generator/dart/painting/PaintingVariantGenerator.kt
@@ -1,5 +1,6 @@
 package net.theevilreaper.stelaris.cli.generator.dart.painting
 
+import com.google.auto.service.AutoService
 import net.minestom.server.entity.metadata.other.PaintingVariant
 import net.theevilreaper.dartpoet.DartFile
 import net.theevilreaper.dartpoet.DartModifier
@@ -10,6 +11,8 @@ import net.theevilreaper.dartpoet.enum.parameter.EnumParameterSpec
 import net.theevilreaper.dartpoet.parameter.ParameterSpec
 import net.theevilreaper.dartpoet.property.PropertySpec
 import net.theevilreaper.stelaris.cli.generator.BaseGenerator
+import net.theevilreaper.stelaris.cli.generator.CodeGenerator
+import net.theevilreaper.stelaris.cli.generator.Generator
 import net.theevilreaper.stelaris.cli.util.EMPTY_STRING
 import net.theevilreaper.stelaris.cli.util.StringHelper
 import java.nio.file.Path
@@ -20,6 +23,8 @@ import java.nio.file.Path
  * @since 1.0.0
  * @author theEvilReaper
  */
+@AutoService(Generator::class)
+@CodeGenerator(name = "PaintingVariantGenerator")
 class PaintingVariantGenerator : BaseGenerator(
     className = "PaintingVariant",
     packageName = "painting",
@@ -78,6 +83,4 @@ class PaintingVariantGenerator : BaseGenerator(
             .build()
         file.write(folder)
     }
-
-    override fun getName() = "PaintingVariantGenerator"
 }

--- a/src/main/kotlin/net/theevilreaper/stelaris/cli/generator/dart/sound/SoundEventGenerator.kt
+++ b/src/main/kotlin/net/theevilreaper/stelaris/cli/generator/dart/sound/SoundEventGenerator.kt
@@ -1,5 +1,6 @@
 package net.theevilreaper.stelaris.cli.generator.dart.sound
 
+import com.google.auto.service.AutoService
 import net.kyori.adventure.key.Key
 import net.minestom.server.sound.SoundEvent
 import net.theevilreaper.dartpoet.DartFile
@@ -11,9 +12,13 @@ import net.theevilreaper.dartpoet.enum.parameter.EnumParameterSpec
 import net.theevilreaper.dartpoet.parameter.ParameterSpec
 import net.theevilreaper.dartpoet.property.PropertySpec
 import net.theevilreaper.stelaris.cli.generator.BaseGenerator
+import net.theevilreaper.stelaris.cli.generator.CodeGenerator
+import net.theevilreaper.stelaris.cli.generator.Generator
 import net.theevilreaper.stelaris.cli.util.StringHelper
 import java.nio.file.Path
 
+@AutoService(Generator::class)
+@CodeGenerator(name = "SoundEventGenerator")
 class SoundEventGenerator : BaseGenerator(
     className = "SoundEvent",
     packageName = "sound",
@@ -65,8 +70,6 @@ class SoundEventGenerator : BaseGenerator(
         // Write all enum files to the folder
         enumFiles.forEach { it.write(folder) }
     }
-
-    override fun getName(): String = "SoundEventGenerator"
 
     private fun buildEnumEntry(soundKey: Key): EnumEntrySpec {
         val parts = soundKey.value().split(".")

--- a/src/main/kotlin/net/theevilreaper/stelaris/cli/generator/dart/sound/SoundSourceGenerator.kt
+++ b/src/main/kotlin/net/theevilreaper/stelaris/cli/generator/dart/sound/SoundSourceGenerator.kt
@@ -1,5 +1,6 @@
 package net.theevilreaper.stelaris.cli.generator.dart.sound
 
+import com.google.auto.service.AutoService
 import net.kyori.adventure.sound.Sound
 import net.theevilreaper.dartpoet.DartFile
 import net.theevilreaper.dartpoet.DartModifier
@@ -10,9 +11,13 @@ import net.theevilreaper.dartpoet.enum.parameter.EnumParameterSpec
 import net.theevilreaper.dartpoet.parameter.ParameterSpec
 import net.theevilreaper.dartpoet.property.PropertySpec
 import net.theevilreaper.stelaris.cli.generator.BaseGenerator
+import net.theevilreaper.stelaris.cli.generator.CodeGenerator
+import net.theevilreaper.stelaris.cli.generator.Generator
 import net.theevilreaper.stelaris.cli.util.StringHelper
 import java.nio.file.Path
 
+@AutoService(Generator::class)
+@CodeGenerator(name = "SoundSourceGenerator")
 class SoundSourceGenerator : BaseGenerator(
     className = "SoundSource",
     packageName = "sound"
@@ -55,6 +60,4 @@ class SoundSourceGenerator : BaseGenerator(
             .build()
         soundSourceFile.write(folder)
     }
-
-    override fun getName(): String = "SoundSourceGenerator"
 }

--- a/src/main/kotlin/net/theevilreaper/stelaris/cli/generator/dart/sound/SoundTypeGenerator.kt
+++ b/src/main/kotlin/net/theevilreaper/stelaris/cli/generator/dart/sound/SoundTypeGenerator.kt
@@ -1,5 +1,6 @@
 package net.theevilreaper.stelaris.cli.generator.dart.sound
 
+import com.google.auto.service.AutoService
 import net.theevilreaper.dartpoet.DartFile
 import net.theevilreaper.dartpoet.DartModifier
 import net.theevilreaper.dartpoet.clazz.ClassSpec
@@ -9,9 +10,13 @@ import net.theevilreaper.dartpoet.enum.parameter.EnumParameterSpec
 import net.theevilreaper.dartpoet.parameter.ParameterSpec
 import net.theevilreaper.dartpoet.property.PropertySpec
 import net.theevilreaper.stelaris.cli.generator.BaseGenerator
+import net.theevilreaper.stelaris.cli.generator.CodeGenerator
+import net.theevilreaper.stelaris.cli.generator.Generator
 import net.theevilreaper.stelaris.cli.util.StringHelper
 import java.nio.file.Path
 
+@AutoService(Generator::class)
+@CodeGenerator(name = "SoundTypeGenerator")
 class SoundTypeGenerator : BaseGenerator(
     className = "SoundType",
     packageName = "sound"
@@ -53,6 +58,4 @@ class SoundTypeGenerator : BaseGenerator(
             .build()
         file.write(folder)
     }
-
-    override fun getName(): String = "SoundTypeGenerator"
 }

--- a/src/main/kotlin/net/theevilreaper/stelaris/cli/generator/dart/villager/VillagerTypeGenerator.kt
+++ b/src/main/kotlin/net/theevilreaper/stelaris/cli/generator/dart/villager/VillagerTypeGenerator.kt
@@ -1,5 +1,6 @@
 package net.theevilreaper.stelaris.cli.generator.dart.villager
 
+import com.google.auto.service.AutoService
 import net.minestom.server.entity.VillagerType
 import net.theevilreaper.dartpoet.DartFile
 import net.theevilreaper.dartpoet.DartModifier
@@ -10,9 +11,13 @@ import net.theevilreaper.dartpoet.enum.parameter.EnumParameterSpec
 import net.theevilreaper.dartpoet.parameter.ParameterSpec
 import net.theevilreaper.dartpoet.property.PropertySpec
 import net.theevilreaper.stelaris.cli.generator.BaseGenerator
+import net.theevilreaper.stelaris.cli.generator.CodeGenerator
+import net.theevilreaper.stelaris.cli.generator.Generator
 import net.theevilreaper.stelaris.cli.util.StringHelper
 import java.nio.file.Path
 
+@AutoService(Generator::class)
+@CodeGenerator(name = "VillagerTypeGenerator")
 class VillagerTypeGenerator : BaseGenerator(
     className = "VillagerType",
     packageName = "villager",
@@ -62,6 +67,4 @@ class VillagerTypeGenerator : BaseGenerator(
             .build()
         enumFile.write(folder)
     }
-
-    override fun getName() = "VillagerTypeGenerator"
 }

--- a/src/main/kotlin/net/theevilreaper/stelaris/cli/generator/dart/world/BiomeGenerator.kt
+++ b/src/main/kotlin/net/theevilreaper/stelaris/cli/generator/dart/world/BiomeGenerator.kt
@@ -1,5 +1,6 @@
 package net.theevilreaper.stelaris.cli.generator.dart.world
 
+import com.google.auto.service.AutoService
 import net.minestom.server.world.biome.Biome
 import net.theevilreaper.dartpoet.DartFile
 import net.theevilreaper.dartpoet.DartModifier
@@ -10,6 +11,8 @@ import net.theevilreaper.dartpoet.enum.parameter.EnumParameterSpec
 import net.theevilreaper.dartpoet.parameter.ParameterSpec
 import net.theevilreaper.dartpoet.property.PropertySpec
 import net.theevilreaper.stelaris.cli.generator.BaseGenerator
+import net.theevilreaper.stelaris.cli.generator.CodeGenerator
+import net.theevilreaper.stelaris.cli.generator.Generator
 import net.theevilreaper.stelaris.cli.util.EMPTY_STRING
 import net.theevilreaper.stelaris.cli.util.StringHelper
 import java.nio.file.Path
@@ -20,6 +23,8 @@ import java.nio.file.Path
  * @since 1.0.0
  * @author theEvilReaper
  */
+@AutoService(Generator::class)
+@CodeGenerator(name = "BiomeGenerator")
 class BiomeGenerator : BaseGenerator(
     className = "Biome",
     packageName = "world",
@@ -80,6 +85,4 @@ class BiomeGenerator : BaseGenerator(
             .build()
         file.write(folder)
     }
-
-    override fun getName() = "BiomeGenerator"
 }

--- a/src/main/kotlin/net/theevilreaper/stelaris/cli/generator/dart/world/DifficultyGenerator.kt
+++ b/src/main/kotlin/net/theevilreaper/stelaris/cli/generator/dart/world/DifficultyGenerator.kt
@@ -1,5 +1,6 @@
 package net.theevilreaper.stelaris.cli.generator.dart.world
 
+import com.google.auto.service.AutoService
 import net.minestom.server.world.Difficulty
 import net.theevilreaper.dartpoet.DartFile
 import net.theevilreaper.dartpoet.DartModifier
@@ -10,6 +11,8 @@ import net.theevilreaper.dartpoet.enum.parameter.EnumParameterSpec
 import net.theevilreaper.dartpoet.parameter.ParameterSpec
 import net.theevilreaper.dartpoet.property.PropertySpec
 import net.theevilreaper.stelaris.cli.generator.BaseGenerator
+import net.theevilreaper.stelaris.cli.generator.CodeGenerator
+import net.theevilreaper.stelaris.cli.generator.Generator
 import net.theevilreaper.stelaris.cli.util.StringHelper
 import java.nio.file.Path
 
@@ -19,6 +22,8 @@ import java.nio.file.Path
  * @since 1.0.0
  * @author theEvilReaper
  */
+@AutoService(Generator::class)
+@CodeGenerator(name = "DifficultyGenerator")
 class DifficultyGenerator : BaseGenerator(
     className = "Difficulty",
     packageName = "world",
@@ -65,6 +70,4 @@ class DifficultyGenerator : BaseGenerator(
             .build()
         file.write(folder)
     }
-
-    override fun getName() = "DifficultyGenerator"
 }

--- a/src/main/kotlin/net/theevilreaper/stelaris/cli/generator/dart/world/DimensionTypeGenerator.kt
+++ b/src/main/kotlin/net/theevilreaper/stelaris/cli/generator/dart/world/DimensionTypeGenerator.kt
@@ -1,5 +1,6 @@
 package net.theevilreaper.stelaris.cli.generator.dart.world
 
+import com.google.auto.service.AutoService
 import net.minestom.server.MinecraftServer
 import net.minestom.server.world.DimensionType
 import net.theevilreaper.dartpoet.DartFile
@@ -11,6 +12,8 @@ import net.theevilreaper.dartpoet.enum.parameter.EnumParameterSpec
 import net.theevilreaper.dartpoet.parameter.ParameterSpec
 import net.theevilreaper.dartpoet.property.PropertySpec
 import net.theevilreaper.stelaris.cli.generator.BaseGenerator
+import net.theevilreaper.stelaris.cli.generator.CodeGenerator
+import net.theevilreaper.stelaris.cli.generator.Generator
 import net.theevilreaper.stelaris.cli.util.EMPTY_STRING
 import net.theevilreaper.stelaris.cli.util.StringHelper
 import java.nio.file.Path
@@ -21,6 +24,8 @@ import java.nio.file.Path
  * @since 1.0.0
  * @author theEvilReaper
  */
+@AutoService(Generator::class)
+@CodeGenerator(name = "DimensionTypeGenerator")
 class DimensionTypeGenerator : BaseGenerator(
     className = "DimensionType",
     packageName = "world",
@@ -91,6 +96,4 @@ class DimensionTypeGenerator : BaseGenerator(
             .build()
         file.write(folder)
     }
-
-    override fun getName() = "DimensionTypeGenerator"
 }

--- a/src/main/kotlin/net/theevilreaper/stelaris/cli/generator/dart/world/GameModeGenerator.kt
+++ b/src/main/kotlin/net/theevilreaper/stelaris/cli/generator/dart/world/GameModeGenerator.kt
@@ -1,5 +1,6 @@
 package net.theevilreaper.stelaris.cli.generator.dart.world
 
+import com.google.auto.service.AutoService
 import net.minestom.server.entity.GameMode
 import net.theevilreaper.dartpoet.DartFile
 import net.theevilreaper.dartpoet.DartModifier
@@ -10,6 +11,8 @@ import net.theevilreaper.dartpoet.enum.parameter.EnumParameterSpec
 import net.theevilreaper.dartpoet.parameter.ParameterSpec
 import net.theevilreaper.dartpoet.property.PropertySpec
 import net.theevilreaper.stelaris.cli.generator.BaseGenerator
+import net.theevilreaper.stelaris.cli.generator.CodeGenerator
+import net.theevilreaper.stelaris.cli.generator.Generator
 import net.theevilreaper.stelaris.cli.util.StringHelper
 import java.nio.file.Path
 
@@ -19,6 +22,8 @@ import java.nio.file.Path
  * @since 1.0.0
  * @author theEvilReaper
  */
+@AutoService(Generator::class)
+@CodeGenerator(name = "GameModeGenerator")
 class GameModeGenerator : BaseGenerator(
     className = "GameMode",
     packageName = "world",
@@ -65,6 +70,4 @@ class GameModeGenerator : BaseGenerator(
             .build()
         file.write(folder)
     }
-
-    override fun getName() = "GameModeGenerator"
 }

--- a/src/test/kotlin/net/theevilreaper/stelaris/cli/exporter/LocalProjectExporterTest.kt
+++ b/src/test/kotlin/net/theevilreaper/stelaris/cli/exporter/LocalProjectExporterTest.kt
@@ -19,9 +19,7 @@ class LocalProjectExporterTest {
             override fun generate(outputPath: Path) {
                 generatedTarget = outputPath
             }
-            override fun getName(): String = "MockGenerator"
             override fun cleanUp() {}
-            override fun isExperimental(): Boolean = false
         }
 
         val exportPath = tempDir.resolve("export_target")

--- a/src/test/kotlin/net/theevilreaper/stelaris/cli/generator/GeneratorModuleTest.kt
+++ b/src/test/kotlin/net/theevilreaper/stelaris/cli/generator/GeneratorModuleTest.kt
@@ -1,0 +1,65 @@
+package net.theevilreaper.stelaris.cli.generator
+
+import com.google.common.reflect.ClassPath
+import com.google.inject.Guice
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class GeneratorModuleTest {
+
+    private val registry = Guice.createInjector(GeneratorModule())
+        .getInstance(GeneratorRegistry::class.java)
+
+    @Test
+    fun `test generators are discovered through the service file`() {
+        assertTrue(registry.getDescriptors().isNotEmpty(), "The service file should list every generator")
+    }
+
+    @Test
+    fun `test every descriptor carries a usable name`() {
+        val names = registry.getDescriptors().map { it.name }
+        names.forEach { assertTrue(it.isNotBlank(), "A generator name must not be blank") }
+        assertEquals(names.size, names.toSet().size, "Generator names must be unique")
+    }
+
+    @Test
+    fun `test every descriptor can create its generator`() {
+        registry.getDescriptors().forEach { descriptor ->
+            assertNotNull(descriptor.create(), "Descriptor $descriptor should create a generator")
+        }
+    }
+
+    /**
+     * Guards the one weakness of service based discovery: a generator whose `@AutoService`
+     * annotation is missing is silently left out of the service file. The compiler cannot catch
+     * that, so the test compares every implementation on the classpath against the discovered set.
+     */
+    @Test
+    @Suppress("UnstableApiUsage")
+    fun `test every generator implementation is registered`() {
+        val discovered = registry.getDescriptors().map { it.name }.toSet()
+
+        val unregistered = ClassPath.from(javaClass.classLoader)
+            .getTopLevelClassesRecursive(GENERATOR_PACKAGE)
+            .filter { it.simpleName.endsWith(GENERATOR_SUFFIX) }
+            .map { it.load() }
+            .filter { Generator::class.java.isAssignableFrom(it) }
+            .filter { type ->
+                val metadata = type.getAnnotation(CodeGenerator::class.java)
+                metadata == null || metadata.name !in discovered
+            }
+            .map { it.name }
+
+        assertTrue(
+            unregistered.isEmpty(),
+            "Missing @AutoService or @CodeGenerator on: ${unregistered.joinToString()}",
+        )
+    }
+
+    private companion object {
+        const val GENERATOR_PACKAGE = "net.theevilreaper.stelaris.cli.generator.dart"
+        const val GENERATOR_SUFFIX = "Generator"
+    }
+}

--- a/src/test/kotlin/net/theevilreaper/stelaris/cli/generator/GeneratorRegistryTest.kt
+++ b/src/test/kotlin/net/theevilreaper/stelaris/cli/generator/GeneratorRegistryTest.kt
@@ -1,14 +1,68 @@
 package net.theevilreaper.stelaris.cli.generator
 
-import org.junit.jupiter.api.Assertions.*
+import jakarta.inject.Provider
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.nio.file.Path
 
 class GeneratorRegistryTest {
 
+    private class NoopGenerator : Generator {
+        override fun generate(outputPath: Path) = Unit
+        override fun cleanUp() = Unit
+    }
+
+    private fun descriptor(
+        name: String,
+        experimental: Boolean = false,
+        onCreate: () -> Unit = {},
+    ) = GeneratorDescriptor(name, experimental, Provider { onCreate(); NoopGenerator() })
+
     @Test
-    fun testGetGenerators() {
-        val generatorRegistry = GeneratorRegistry()
-        val generators = generatorRegistry.getGenerators()
-        assertEquals(28, generators.size)
+    fun `test registry rejects an empty descriptor set`() {
+        val exception = assertThrows<IllegalStateException> { GeneratorRegistry(emptySet()) }
+        assertTrue(
+            exception.message!!.contains("mergeServiceFiles()"),
+            "The message should point at the most likely cause",
+        )
+    }
+
+    @Test
+    fun `test registry rejects duplicated generator names`() {
+        val exception = assertThrows<IllegalStateException> {
+            GeneratorRegistry(setOf(descriptor("SoundEventGenerator"), descriptor("SoundEventGenerator")))
+        }
+        assertTrue(exception.message!!.contains("SoundEventGenerator"), "The message should name the duplicate")
+    }
+
+    @Test
+    fun `test all descriptors are returned`() {
+        val registry = GeneratorRegistry(setOf(descriptor("First"), descriptor("Second")))
+        assertEquals(setOf("First", "Second"), registry.getDescriptors().map { it.name }.toSet())
+    }
+
+    @Test
+    fun `test filtered out generators are never created`() {
+        var experimentalCreated = false
+        val registry = GeneratorRegistry(
+            setOf(
+                descriptor("Stable"),
+                descriptor("Experimental", experimental = true) { experimentalCreated = true },
+            ),
+        )
+
+        val generators = registry.createGenerators { !it.experimental }
+
+        assertEquals(1, generators.size, "Only the stable generator should be created")
+        assertFalse(experimentalCreated, "An excluded generator must not be instantiated")
+    }
+
+    @Test
+    fun `test createGenerators without a filter creates every generator`() {
+        val registry = GeneratorRegistry(setOf(descriptor("First"), descriptor("Second")))
+        assertEquals(2, registry.createGenerators().size)
     }
 }

--- a/src/test/kotlin/net/theevilreaper/stelaris/cli/generator/dart/EntityTypeGeneratorTest.kt
+++ b/src/test/kotlin/net/theevilreaper/stelaris/cli/generator/dart/EntityTypeGeneratorTest.kt
@@ -11,7 +11,6 @@ class EntityTypeGeneratorTest : GenerationTestBase() {
     @Test
     fun `test entity type generation`() {
         val generator = EntityTypeGenerator()
-        assertEquals("EntityTypeGenerator", generator.getName())
 
         generator.generate(generationPath)
 

--- a/src/test/kotlin/net/theevilreaper/stelaris/cli/generator/dart/FrameTypeGeneratorTest.kt
+++ b/src/test/kotlin/net/theevilreaper/stelaris/cli/generator/dart/FrameTypeGeneratorTest.kt
@@ -11,7 +11,6 @@ class FrameTypeGeneratorTest : GenerationTestBase() {
     @Test
     fun `test frame type generation`() {
         val generator = FrameTypeGenerator()
-        assertEquals("FrameTypeGenerator", generator.getName())
 
         generator.generate(generationPath)
 

--- a/src/test/kotlin/net/theevilreaper/stelaris/cli/generator/dart/MaterialGeneratorTest.kt
+++ b/src/test/kotlin/net/theevilreaper/stelaris/cli/generator/dart/MaterialGeneratorTest.kt
@@ -16,7 +16,6 @@ class MaterialGeneratorTest : GenerationTestBase() {
     @Test
     fun `test material generation`(env: Env) {
         val generator = MaterialGenerator()
-        assertEquals("MaterialGenerator", generator.getName())
 
         generator.generate(generationPath)
 

--- a/src/test/kotlin/net/theevilreaper/stelaris/cli/generator/dart/banner/BannerPatternGeneratorTest.kt
+++ b/src/test/kotlin/net/theevilreaper/stelaris/cli/generator/dart/banner/BannerPatternGeneratorTest.kt
@@ -11,7 +11,6 @@ class BannerPatternGeneratorTest : GenerationTestBase() {
     @Test
     fun `test banner pattern generation`() {
         val generator = BannerPatternGenerator()
-        assertEquals("BannerPatternGenerator", generator.getName())
 
         generator.generate(generationPath)
 

--- a/src/test/kotlin/net/theevilreaper/stelaris/cli/generator/dart/color/DyeColorGeneratorTest.kt
+++ b/src/test/kotlin/net/theevilreaper/stelaris/cli/generator/dart/color/DyeColorGeneratorTest.kt
@@ -11,7 +11,6 @@ class DyeColorGeneratorTest : GenerationTestBase() {
     @Test
     fun `test dye color generation`() {
         val generator = DyeColorGenerator()
-        assertEquals("DyeColorGenerator", generator.getName())
 
         generator.generate(generationPath)
 

--- a/src/test/kotlin/net/theevilreaper/stelaris/cli/generator/dart/damage/DamageTypeGeneratorTest.kt
+++ b/src/test/kotlin/net/theevilreaper/stelaris/cli/generator/dart/damage/DamageTypeGeneratorTest.kt
@@ -11,7 +11,6 @@ class DamageTypeGeneratorTest : GenerationTestBase() {
     @Test
     fun `test damage type generation`() {
         val generator = DamageTypeGenerator()
-        assertEquals("DamageTypeGenerator", generator.getName())
 
         generator.generate(generationPath)
 

--- a/src/test/kotlin/net/theevilreaper/stelaris/cli/generator/dart/entity/variant/EntityVariantGeneratorTest.kt
+++ b/src/test/kotlin/net/theevilreaper/stelaris/cli/generator/dart/entity/variant/EntityVariantGeneratorTest.kt
@@ -11,7 +11,6 @@ class EntityVariantGeneratorTest : GenerationTestBase() {
     @Test
     fun `test entity variant generation`() {
         val generator = EntityVariantGenerator()
-        assertEquals("EntityVariantGenerator", generator.getName())
 
         generator.generate(generationPath)
 

--- a/src/test/kotlin/net/theevilreaper/stelaris/cli/generator/dart/item/FireworkShapeGeneratorTest.kt
+++ b/src/test/kotlin/net/theevilreaper/stelaris/cli/generator/dart/item/FireworkShapeGeneratorTest.kt
@@ -11,7 +11,6 @@ class FireworkShapeGeneratorTest : GenerationTestBase() {
     @Test
     fun `test firework shape generation`() {
         val generator = FireworkShapeGenerator()
-        assertEquals("FireworkShapeGenerator", generator.getName())
 
         generator.generate(generationPath)
 

--- a/src/test/kotlin/net/theevilreaper/stelaris/cli/generator/dart/item/InstrumentGeneratorTest.kt
+++ b/src/test/kotlin/net/theevilreaper/stelaris/cli/generator/dart/item/InstrumentGeneratorTest.kt
@@ -11,7 +11,6 @@ class InstrumentGeneratorTest : GenerationTestBase() {
     @Test
     fun `test instrument generation`() {
         val generator = InstrumentGenerator()
-        assertEquals("InstrumentGenerator", generator.getName())
 
         generator.generate(generationPath)
 

--- a/src/test/kotlin/net/theevilreaper/stelaris/cli/generator/dart/item/ItemRarityGeneratorTest.kt
+++ b/src/test/kotlin/net/theevilreaper/stelaris/cli/generator/dart/item/ItemRarityGeneratorTest.kt
@@ -11,7 +11,6 @@ class ItemRarityGeneratorTest : GenerationTestBase() {
     @Test
     fun `test item rarity generation`() {
         val generator = ItemRarityGenerator()
-        assertEquals("ItemRarityGenerator", generator.getName())
 
         generator.generate(generationPath)
 

--- a/src/test/kotlin/net/theevilreaper/stelaris/cli/generator/dart/item/JukeboxSongGeneratorTest.kt
+++ b/src/test/kotlin/net/theevilreaper/stelaris/cli/generator/dart/item/JukeboxSongGeneratorTest.kt
@@ -11,7 +11,6 @@ class JukeboxSongGeneratorTest : GenerationTestBase() {
     @Test
     fun `test jukebox song generation`() {
         val generator = JukeboxSongGenerator()
-        assertEquals("JukeboxSongGenerator", generator.getName())
 
         generator.generate(generationPath)
 

--- a/src/test/kotlin/net/theevilreaper/stelaris/cli/generator/dart/item/MapPostProcessingGeneratorTest.kt
+++ b/src/test/kotlin/net/theevilreaper/stelaris/cli/generator/dart/item/MapPostProcessingGeneratorTest.kt
@@ -11,7 +11,6 @@ class MapPostProcessingGeneratorTest : GenerationTestBase() {
     @Test
     fun `test map post processing generation`() {
         val generator = MapPostProcessingGenerator()
-        assertEquals("MapPostProcessingGenerator", generator.getName())
 
         generator.generate(generationPath)
 

--- a/src/test/kotlin/net/theevilreaper/stelaris/cli/generator/dart/item/TrimMaterialGeneratorTest.kt
+++ b/src/test/kotlin/net/theevilreaper/stelaris/cli/generator/dart/item/TrimMaterialGeneratorTest.kt
@@ -11,7 +11,6 @@ class TrimMaterialGeneratorTest : GenerationTestBase() {
     @Test
     fun `test trim material generation`() {
         val generator = TrimMaterialGenerator()
-        assertEquals("TrimMaterialGenerator", generator.getName())
 
         generator.generate(generationPath)
 

--- a/src/test/kotlin/net/theevilreaper/stelaris/cli/generator/dart/item/TrimPatternGeneratorTest.kt
+++ b/src/test/kotlin/net/theevilreaper/stelaris/cli/generator/dart/item/TrimPatternGeneratorTest.kt
@@ -11,7 +11,6 @@ class TrimPatternGeneratorTest : GenerationTestBase() {
     @Test
     fun `test trim pattern generation`() {
         val generator = TrimPatternGenerator()
-        assertEquals("TrimPatternGenerator", generator.getName())
 
         generator.generate(generationPath)
 

--- a/src/test/kotlin/net/theevilreaper/stelaris/cli/generator/dart/painting/PaintingVariantGeneratorTest.kt
+++ b/src/test/kotlin/net/theevilreaper/stelaris/cli/generator/dart/painting/PaintingVariantGeneratorTest.kt
@@ -11,7 +11,6 @@ class PaintingVariantGeneratorTest : GenerationTestBase() {
     @Test
     fun `test painting variant generation`() {
         val generator = PaintingVariantGenerator()
-        assertEquals("PaintingVariantGenerator", generator.getName())
 
         generator.generate(generationPath)
 

--- a/src/test/kotlin/net/theevilreaper/stelaris/cli/generator/dart/villager/VillagerTypeGeneratorTest.kt
+++ b/src/test/kotlin/net/theevilreaper/stelaris/cli/generator/dart/villager/VillagerTypeGeneratorTest.kt
@@ -11,7 +11,6 @@ class VillagerTypeGeneratorTest : GenerationTestBase() {
     @Test
     fun `test villager type generation`() {
         val generator = VillagerTypeGenerator()
-        assertEquals("VillagerTypeGenerator", generator.getName())
 
         generator.generate(generationPath)
 

--- a/src/test/kotlin/net/theevilreaper/stelaris/cli/generator/dart/world/BiomeGeneratorTest.kt
+++ b/src/test/kotlin/net/theevilreaper/stelaris/cli/generator/dart/world/BiomeGeneratorTest.kt
@@ -11,7 +11,6 @@ class BiomeGeneratorTest : GenerationTestBase() {
     @Test
     fun `test biome generation`() {
         val generator = BiomeGenerator()
-        assertEquals("BiomeGenerator", generator.getName())
 
         generator.generate(generationPath)
 

--- a/src/test/kotlin/net/theevilreaper/stelaris/cli/generator/dart/world/DifficultyGeneratorTest.kt
+++ b/src/test/kotlin/net/theevilreaper/stelaris/cli/generator/dart/world/DifficultyGeneratorTest.kt
@@ -11,7 +11,6 @@ class DifficultyGeneratorTest : GenerationTestBase() {
     @Test
     fun `test difficulty generation`() {
         val generator = DifficultyGenerator()
-        assertEquals("DifficultyGenerator", generator.getName())
 
         generator.generate(generationPath)
 

--- a/src/test/kotlin/net/theevilreaper/stelaris/cli/generator/dart/world/DimensionTypeGeneratorTest.kt
+++ b/src/test/kotlin/net/theevilreaper/stelaris/cli/generator/dart/world/DimensionTypeGeneratorTest.kt
@@ -11,7 +11,6 @@ class DimensionTypeGeneratorTest : GenerationTestBase() {
     @Test
     fun `test dimension type generation`() {
         val generator = DimensionTypeGenerator()
-        assertEquals("DimensionTypeGenerator", generator.getName())
 
         generator.generate(generationPath)
 

--- a/src/test/kotlin/net/theevilreaper/stelaris/cli/generator/dart/world/GameModeGeneratorTest.kt
+++ b/src/test/kotlin/net/theevilreaper/stelaris/cli/generator/dart/world/GameModeGeneratorTest.kt
@@ -11,7 +11,6 @@ class GameModeGeneratorTest : GenerationTestBase() {
     @Test
     fun `test game mode generation`() {
         val generator = GameModeGenerator()
-        assertEquals("GameModeGenerator", generator.getName())
 
         generator.generate(generationPath)
 


### PR DESCRIPTION
## Context

`GeneratorRegistry` kept all 28 generators in a hardcoded `setOf(...)`. Every new generator had to be registered in a second place, a forgotten entry went unnoticed, and every instance was created when the registry was constructed — including the ones the run never used.

Generators now register themselves: a class with `@AutoService(Generator::class)` and `@CodeGenerator(...)` is discovered automatically.

## How it works

`@AutoService` writes the `META-INF/services` entry at compile time; `GeneratorModule` reads it and binds each class as a `GeneratorDescriptor` through a `Multibinder`.

The key detail: `ServiceLoader` is used for discovery only. `service.type()` returns the class without instantiating it, and Guice constructs the instance via `getProvider(type)`. That keeps creation lazy and leaves room for generators to take `@Inject` dependencies later.

`GeneratorRegistry` filters descriptors rather than generators, so a non-experimental run no longer constructs experimental generators. It rejects an empty set (with a hint at `mergeServiceFiles()`) and duplicated names before any generator runs.

Alternatives that were rejected — explicit multibinder bindings, a runtime classpath scan, a hand-written KSP processor — are documented in the design doc in the first commit.

## Interface change

`getName()` and `isExperimental()` leave the `Generator` interface; the metadata lives on the annotation. Worth noting: `getName()` had no caller in main sources at all, it existed so that 20 tests could assert the class name.

## Verification

- `./gradlew build` green, including the new `verifyShadowJarServices` task (`Shadow jar registers 28 generators`).
- Ran the shadow jar against an output directory and compared it against a `develop` build: **3653 enum entries on both sides, 33 of 51 files byte-identical**.
- The 18 differing files are pre-existing non-determinism, not a regression: running the **unchanged `develop` jar twice** produces differences in exactly the same 18 files. Entity, material and sound generators apparently iterate over an unordered collection. Out of scope here, but worth its own issue.

## Review notes

Two things are worth a look: whether `getName()` and `isExperimental()` should really leave the interface, and whether the completeness test in `GeneratorModuleTest` — which compares every `Generator` implementation on the classpath against the discovered set — is sufficient protection against a forgotten `@AutoService`.